### PR TITLE
SOV-1551: refresh dapp info when block changes

### DIFF
--- a/.changeset/eighty-mayflies-lie.md
+++ b/.changeset/eighty-mayflies-lie.md
@@ -1,0 +1,5 @@
+---
+"frontend": patch
+---
+
+SOV-1551: refresh dapp info when block changes

--- a/apps/frontend/src/app/2_molecules/DebugContent.tsx
+++ b/apps/frontend/src/app/2_molecules/DebugContent.tsx
@@ -11,7 +11,6 @@ import { AmountInput, Button, NotificationType } from '@sovryn/ui';
 
 import { defaultChainId } from '../../config/chains';
 
-import { TransactionStepDialog } from '../3_organisms';
 import { EmailNotificationSettingsDialog } from '../3_organisms/EmailNotificationSettingsDialog/EmailNotificationSettingsDialog';
 import { GettingStartedPopup } from '../3_organisms/GettingStartedPopup/GettingStartedPopup';
 import { useNotificationContext } from '../../contexts/NotificationContext';
@@ -203,7 +202,6 @@ export const DebugContent = () => {
           <Button text="Connect to RSK Testnet" onClick={connectWallet} />
         )}
       </div>
-      <TransactionStepDialog />
       <ExampleProviderCall />
       <ExampleTokenDetails />
       <ExampleBalanceCall />

--- a/apps/frontend/src/app/2_molecules/SystemStats/components/ZeroStats.tsx
+++ b/apps/frontend/src/app/2_molecules/SystemStats/components/ZeroStats.tsx
@@ -21,6 +21,7 @@ import {
   Tooltip,
 } from '@sovryn/ui';
 
+import { useBlockNumber } from '../../../../hooks/useBlockNumber';
 import { translations } from '../../../../locales/i18n';
 import { Bitcoin } from '../../../../utils/constants';
 import { formatCompactValue, formatValue } from '../../../../utils/math';
@@ -34,6 +35,7 @@ type ZeroStatsProps = {
 
 export const ZeroStats: FC<ZeroStatsProps> = ({ className, dataAttribute }) => {
   const { t } = useTranslation();
+  const { value: blockNumber } = useBlockNumber();
   const [lineOfCredit, setLineOfCredit] = useState('0');
   const [zusdInStabilityPool, setZusdInStabilityPool] = useState<Decimal>();
   const [zusdSupply, setZusdSupply] = useState<Decimal>();
@@ -98,7 +100,7 @@ export const ZeroStats: FC<ZeroStatsProps> = ({ className, dataAttribute }) => {
     liquity
       .getNumberOfTroves()
       .then(result => setLineOfCredit(result.toString()));
-  }, [liquity]);
+  }, [liquity, blockNumber]);
 
   useEffect(() => {
     liquity.getTotal().then(result => {
@@ -120,7 +122,7 @@ export const ZeroStats: FC<ZeroStatsProps> = ({ className, dataAttribute }) => {
         setZeroInStabilityPoolPercent(percent?.toString(2));
       }
     });
-  }, [liquity, zeroPrice, zusdInStabilityPool]);
+  }, [liquity, zeroPrice, zusdInStabilityPool, blockNumber]);
 
   return (
     <div className={className} {...applyDataAttr(dataAttribute)}>

--- a/apps/frontend/src/app/3_organisms/FastBtcDialog/components/SendFlow/components/ReviewScreen.tsx
+++ b/apps/frontend/src/app/3_organisms/FastBtcDialog/components/SendFlow/components/ReviewScreen.tsx
@@ -13,7 +13,6 @@ import {
   getRskExplorerUrl,
 } from '../../../../../../utils/helpers';
 import { formatValue } from '../../../../../../utils/math';
-import { TransactionStepDialog } from '../../../../TransactionStepDialog';
 
 const translation = translations.fastBtc.send.confirmationScreens;
 
@@ -114,7 +113,6 @@ export const ReviewScreen: React.FC<ReviewScreenProps> = ({
         />
         {fastBtcLocked && <div>{t(translations.maintenanceMode.fastBtc)}</div>}
       </div>
-      <TransactionStepDialog disableFocusTrap />
     </div>
   );
 };

--- a/apps/frontend/src/app/3_organisms/TransactionStepDialog/components/TransactionStep/TransactionStep.tsx
+++ b/apps/frontend/src/app/3_organisms/TransactionStepDialog/components/TransactionStep/TransactionStep.tsx
@@ -57,7 +57,6 @@ export const TransactionStep: FC<TransactionStepProps> = ({
 
   useEffect(() => {
     findContract(transaction.contract.address).then(result => {
-      console.log('result', result);
       if (result.group === 'tokens') {
         getTokenDetailsByAddress(transaction.contract.address).then(setToken);
       }

--- a/apps/frontend/src/app/3_organisms/TransactionStepDialog/components/TransactionStep/TransactionStep.tsx
+++ b/apps/frontend/src/app/3_organisms/TransactionStepDialog/components/TransactionStep/TransactionStep.tsx
@@ -57,6 +57,7 @@ export const TransactionStep: FC<TransactionStepProps> = ({
 
   useEffect(() => {
     findContract(transaction.contract.address).then(result => {
+      console.log('result', result);
       if (result.group === 'tokens') {
         getTokenDetailsByAddress(transaction.contract.address).then(setToken);
       }
@@ -196,9 +197,9 @@ export const TransactionStep: FC<TransactionStepProps> = ({
           {config.amount !== undefined && (
             <SimpleTableRow
               label="Amount"
-              value={`${config.unlimitedAmount ? '∞' : parsedAmount} ${
-                token?.symbol
-              }`}
+              value={`${
+                config.unlimitedAmount ? '∞' : parsedAmount
+              } ${token?.symbol?.toUpperCase()}`}
               valueClassName={classNames(
                 isLoading || status === StatusType.success
                   ? 'text-gray-30'

--- a/apps/frontend/src/app/5_pages/ConvertPage/ConvertPage.tsx
+++ b/apps/frontend/src/app/5_pages/ConvertPage/ConvertPage.tsx
@@ -20,7 +20,6 @@ import {
 } from '@sovryn/ui';
 
 import { AssetRenderer } from '../../2_molecules/AssetRenderer/AssetRenderer';
-import { TransactionStepDialog } from '../../3_organisms';
 import { useAccount } from '../../../hooks/useAccount';
 import { translations } from '../../../locales/i18n';
 import { formatValue } from '../../../utils/math';
@@ -258,7 +257,6 @@ const ConvertPage: FC = () => {
           dataAttribute="convert-confirm"
         />
       </div>
-      <TransactionStepDialog />
     </div>
   );
 };

--- a/apps/frontend/src/app/5_pages/ConvertPage/hooks/useGetMaximumAvailableAmount.ts
+++ b/apps/frontend/src/app/5_pages/ConvertPage/hooks/useGetMaximumAvailableAmount.ts
@@ -7,6 +7,7 @@ import { getProtocolContract, SupportedTokens } from '@sovryn/contracts';
 import { defaultChainId } from '../../../../config/chains';
 
 import { useAssetBalance } from '../../../../hooks/useAssetBalance';
+import { useIsMounted } from '../../../../hooks/useIsMounted';
 import { fromWei } from '../../../../utils/math';
 import { bassets, masset } from '../ConvertPage.types';
 import { useGetSourceTokenBalance } from './useGetSourceTokenBalance';
@@ -15,6 +16,8 @@ export const useGetMaximumAvailableAmount = (
   sourceToken: SupportedTokens,
   destinationToken: SupportedTokens,
 ) => {
+  const isMounted = useIsMounted();
+
   //  bAsset => DLLR conversion
   const isMint = useMemo(
     () => bassets.includes(sourceToken) && destinationToken === masset,
@@ -35,8 +38,12 @@ export const useGetMaximumAvailableAmount = (
       return massetManagerAddress;
     };
 
-    getMassetManagerDetails().then(result => setMassetManagerAddress(result));
-  }, []);
+    getMassetManagerDetails().then(result => {
+      if (isMounted()) {
+        setMassetManagerAddress(result);
+      }
+    });
+  }, [isMounted]);
 
   const { value: destinationTokenAggregatorWeiBalance } = useAssetBalance(
     destinationToken,

--- a/apps/frontend/src/app/5_pages/RewardsPage/RewardsPage.tsx
+++ b/apps/frontend/src/app/5_pages/RewardsPage/RewardsPage.tsx
@@ -21,7 +21,6 @@ import {
   ParagraphStyle,
 } from '@sovryn/ui';
 
-import { TransactionStepDialog } from '../../3_organisms';
 import { useAccount } from '../../../hooks/useAccount';
 import { useGetOpenTrove } from '../../../hooks/zero/useGetOpenTrove';
 import { translations } from '../../../locales/i18n';
@@ -103,7 +102,6 @@ const RewardsPage: FC = () => {
           )}
         </div>
       </div>
-      <TransactionStepDialog />
     </div>
   );
 };

--- a/apps/frontend/src/hooks/useAssetBalance.ts
+++ b/apps/frontend/src/hooks/useAssetBalance.ts
@@ -75,7 +75,10 @@ export const useAssetBalance = (
                 .balanceOf(account)
                 .then(result => result.toString());
 
-      startCall(hashedArgs, callback, options);
+      startCall(hashedArgs, callback, {
+        ...options,
+        blockNumber: options?.blockNumber || block,
+      });
     };
 
     runAsync().catch(e => setState({ value: '0', loading: false, error: e }));

--- a/apps/frontend/src/index.tsx
+++ b/apps/frontend/src/index.tsx
@@ -39,7 +39,7 @@ root.render(
             </NotificationProvider>
           </MaintenanceModeContextProvider>
         </ApolloProvider>
-        <TransactionStepDialog />
+        <TransactionStepDialog disableFocusTrap />
       </TransactionProvider>
     </NetworkProvider>
   </React.StrictMode>,

--- a/apps/frontend/src/store/rxjs/provider-cache.ts
+++ b/apps/frontend/src/store/rxjs/provider-cache.ts
@@ -71,8 +71,6 @@ export const startCall = <T>(
     return;
   }
 
-  console.log('start', id, options);
-
   const promise$ = promise()
     .then(result => {
       completeCall(id, result, null);


### PR DESCRIPTION
https://sovryn.atlassian.net/browse/SOV-1551

also two extra changes:
1. changed how cache works for tx reading - it now checks for `ttl` and `blockNumber` to decide if data should be expired. It fixes minor glitching of user balances becoming 0 for a moment when new data comes in.
2. removed TransactionSteps component from other pages, because only one component should be imported at the top level of the dapp (otherwise multiple tx dialogs will be opened one on top of another)