### PR TITLE
SOV-2595: Disable ETHs and BNBs in AMM swap route

### DIFF
--- a/.changeset/gentle-drinks-argue.md
+++ b/.changeset/gentle-drinks-argue.md
@@ -1,0 +1,5 @@
+---
+"@sovryn/sdk": patch
+---
+
+SOV-2595: Disable ETHs and BNBs in AMM swap route

--- a/packages/sdk/src/_tests/swaps/smart-router.test.ts
+++ b/packages/sdk/src/_tests/swaps/smart-router.test.ts
@@ -115,11 +115,11 @@ describe('SmartRouter', () => {
     });
 
     it('returns all available entries', async () => {
-      await expect(router.getEntries()).resolves.toHaveLength(10);
+      await expect(router.getEntries()).resolves.toHaveLength(8);
     });
 
     it('returns all available destinations for entry token', async () => {
-      await expect(router.getDestination(sov)).resolves.toHaveLength(7);
+      await expect(router.getDestination(sov)).resolves.toHaveLength(5);
     });
 
     it('returns data about token', async () => {

--- a/packages/sdk/src/swaps/smart-router/routes/amm-swap-route.ts
+++ b/packages/sdk/src/swaps/smart-router/routes/amm-swap-route.ts
@@ -101,13 +101,14 @@ export const ammSwapRoute: SwapRouteFunction = (
 
         const swapTokens = [
           SupportedTokens.rbtc,
-          SupportedTokens.bnbs,
           SupportedTokens.dllr,
-          SupportedTokens.eths,
           SupportedTokens.fish,
           SupportedTokens.moc,
           SupportedTokens.rif,
           SupportedTokens.sov,
+          // Temporarily disabled in https://sovryn.atlassian.net/browse/SOV-2595
+          // SupportedTokens.eths,
+          // SupportedTokens.bnbs,
         ];
 
         const contracts = await Promise.all(


### PR DESCRIPTION
Resolves https://sovryn.atlassian.net/browse/SOV-2595