### PR TITLE
SOV-2659: IPFS - make unpinning a prerequisite for build upload

### DIFF
--- a/.changeset/big-rabbits-kiss.md
+++ b/.changeset/big-rabbits-kiss.md
@@ -1,0 +1,5 @@
+---
+
+---
+
+SOV-2659: IPFS - make unpinning a prerequisite for build upload

--- a/.github/workflows/release-frontend-build-ipfs.yml
+++ b/.github/workflows/release-frontend-build-ipfs.yml
@@ -26,6 +26,7 @@ jobs:
           pinataSecret: ${{ secrets.PINATA_SECRET }}
   upload_build:
     name: Upload Frontend Build To IPFS
+    needs: unpin_previous_builds
     runs-on: ubuntu-latest
     outputs:
       commit_short_hash: ${{ steps.commit.outputs.short }}


### PR DESCRIPTION
Resolves https://sovryn.atlassian.net/browse/SOV-2659