### PR TITLE
SOV-4023: Rune Bridge BOB support

### DIFF
--- a/.changeset/famous-moons-work.md
+++ b/.changeset/famous-moons-work.md
@@ -1,0 +1,6 @@
+---
+"frontend": patch
+"@sovryn/contracts": patch
+---
+
+SOV-4023: Rune Bridge BOB support

--- a/apps/frontend/src/app/3_organisms/RuneBridgeDialog/api/RuneBridgeClient.tsx
+++ b/apps/frontend/src/app/3_organisms/RuneBridgeDialog/api/RuneBridgeClient.tsx
@@ -7,10 +7,14 @@ export interface RequestOpts {
 class ApiError extends Error {}
 
 class RuneBridgeClient {
-  private baseUrl: string;
+  private readonly _baseUrl: string;
 
   constructor(baseUrl: string) {
-    this.baseUrl = baseUrl.replace(/\/*$/, '');
+    this._baseUrl = this.sanitizeUrl(baseUrl);
+  }
+
+  private sanitizeUrl(url: string): string {
+    return url.replace(/\/*$/, '');
   }
 
   async request(
@@ -80,7 +84,7 @@ class RuneBridgeClient {
     if (path.charAt(0) !== '/') {
       path = '/' + path;
     }
-    return `${this.baseUrl}${path}`;
+    return `${this._baseUrl}${path}`;
   }
 }
 

--- a/apps/frontend/src/app/3_organisms/RuneBridgeDialog/api/index.ts
+++ b/apps/frontend/src/app/3_organisms/RuneBridgeDialog/api/index.ts
@@ -1,7 +1,0 @@
-import { currentNetwork } from '../../../../utils/helpers';
-import { endpoints } from '../config';
-import RuneBridgeClient from './RuneBridgeClient';
-
-const baseUrl = `${endpoints[currentNetwork]}/api/v1`;
-
-export const runeBridgeApiClient = new RuneBridgeClient(baseUrl);

--- a/apps/frontend/src/app/3_organisms/RuneBridgeDialog/components/ReceiveFlow/components/StatusScreen.tsx
+++ b/apps/frontend/src/app/3_organisms/RuneBridgeDialog/components/ReceiveFlow/components/StatusScreen.tsx
@@ -16,33 +16,30 @@ import { StatusIcon } from '../../../../../2_molecules/StatusIcon/StatusIcon';
 import { TxIdWithNotification } from '../../../../../2_molecules/TxIdWithNotification/TransactionIdWithNotification';
 import { useAccount } from '../../../../../../hooks/useAccount';
 import { translations } from '../../../../../../locales/i18n';
-import {
-  getBtcExplorerUrl,
-  getRskExplorerUrl,
-} from '../../../../../../utils/helpers';
+import { getBtcExplorerUrl } from '../../../../../../utils/helpers';
 import { formatValue } from '../../../../../../utils/math';
 import {
   ReceiveflowStep,
   TransferStatusType,
 } from '../../../contexts/receiveflow';
 import { useReceiveFlowContext } from '../../../contexts/receiveflow';
+import { useChainDetails } from '../../../hooks/useChainDetails';
 
 const translation = translations.runeBridge.receive.statusScreen;
 
-const rskExplorerUrl = getRskExplorerUrl();
 const btcExplorerUrl = getBtcExplorerUrl();
 
 type StatusScreenProps = {
   onClose: () => void;
 };
 
-const formatTxStatus = (status: TransferStatusType) => {
+const formatTxStatus = (status: TransferStatusType, chainName: string) => {
   switch (status) {
     case 'detected':
     case 'seen':
     case 'sent_to_evm':
     case 'confirmed':
-      return t(translation.transferStatus[status]);
+      return t(translation.transferStatus[status], { chainName });
     default:
       return status;
   }
@@ -51,7 +48,7 @@ const formatTxStatus = (status: TransferStatusType) => {
 export const StatusScreen: React.FC<StatusScreenProps> = ({ onClose }) => {
   const { account } = useAccount();
   const { step, depositTx } = useReceiveFlowContext();
-
+  const { explorerUrl, chainName } = useChainDetails();
   const isProcessing = useMemo(
     () => step === ReceiveflowStep.PROCESSING,
     [step],
@@ -70,7 +67,7 @@ export const StatusScreen: React.FC<StatusScreenProps> = ({ onClose }) => {
         value: (
           <TxIdWithNotification
             value={account}
-            href={`${rskExplorerUrl}/address/${account}`}
+            href={`${explorerUrl}/address/${account}`}
           />
         ),
       },
@@ -118,12 +115,12 @@ export const StatusScreen: React.FC<StatusScreenProps> = ({ onClose }) => {
         ),
       },
       {
-        label: t(translation.rootstockTxId),
+        label: t(translation.currentChainTxId, { chainName }),
         value: currentTX ? (
           <>
             <TxIdWithNotification
               value={currentTX.evmTransferTxHash}
-              href={`${rskExplorerUrl}/tx/${currentTX.evmTransferTxHash}`}
+              href={`${explorerUrl}/tx/${currentTX.evmTransferTxHash}`}
             />
           </>
         ) : (
@@ -131,7 +128,7 @@ export const StatusScreen: React.FC<StatusScreenProps> = ({ onClose }) => {
         ),
       },
     ].filter(x => x);
-  }, [account, depositTx]);
+  }, [account, chainName, depositTx, explorerUrl]);
 
   return (
     <>
@@ -148,7 +145,9 @@ export const StatusScreen: React.FC<StatusScreenProps> = ({ onClose }) => {
             dataAttribute="funding-receive-status"
           />
         </div>
-        <div className="mb-6">{formatTxStatus(depositTx.currentTX.status)}</div>
+        <div className="mb-6">
+          {formatTxStatus(depositTx.currentTX.status, chainName)}
+        </div>
 
         <div className="bg-gray-80 border rounded border-gray-50 p-3 text-xs text-gray-30">
           {items.map(({ label, value }, index) => (

--- a/apps/frontend/src/app/3_organisms/RuneBridgeDialog/components/SendFlow/components/AmountForm.tsx
+++ b/apps/frontend/src/app/3_organisms/RuneBridgeDialog/components/SendFlow/components/AmountForm.tsx
@@ -17,13 +17,14 @@ import {
 
 import { MaxButton } from '../../../../../2_molecules/MaxButton/MaxButton';
 import { TOKEN_RENDER_PRECISION } from '../../../../../../constants/currencies';
-import { BITCOIN } from '../../../../../../constants/currencies';
+import { useCurrentChain } from '../../../../../../hooks/useChainStore';
 import { useGetProtocolContract } from '../../../../../../hooks/useGetContract';
 import { translations } from '../../../../../../locales/i18n';
 import { fromWei, toWei } from '../../../../../../utils/math';
 import { GAS_LIMIT_RUNE_BRIDGE_WITHDRAW } from '../../../constants';
 import { useRuneContext } from '../../../contexts/rune';
 import { SendFlowContext, SendFlowStep } from '../../../contexts/sendflow';
+import { useChainDetails } from '../../../hooks/useChainDetails';
 import { useRuneBridgeLocked } from '../../../hooks/useRuneBridgeLocked';
 import { TransferPolicies } from '../../TransferPolicies';
 
@@ -31,7 +32,9 @@ export const AmountForm: React.FC = () => {
   const { amount, limits, selectedToken, set } = useContext(SendFlowContext);
   const { tokenBalances } = useRuneContext();
   const runeBridgeLocked = useRuneBridgeLocked();
-  const runeBridgeContract = useGetProtocolContract('runeBridge');
+  const chainId = useCurrentChain();
+  const runeBridgeContract = useGetProtocolContract('runeBridge', chainId);
+  const { baseCurrency } = useChainDetails();
 
   const [value, setValue] = useState(amount || '');
 
@@ -204,7 +207,7 @@ export const AmountForm: React.FC = () => {
                   ? `${limits.flatFeeTokens} ${selectedToken.symbol}`
                   : '',
                 limits.flatFeeBaseCurrency
-                  ? `${limits.flatFeeBaseCurrency} ${BITCOIN}`
+                  ? `${limits.flatFeeBaseCurrency} ${baseCurrency}`
                   : '',
               ]
                 .filter(x => x)

--- a/apps/frontend/src/app/3_organisms/RuneBridgeDialog/components/SendFlow/components/ReviewScreen.tsx
+++ b/apps/frontend/src/app/3_organisms/RuneBridgeDialog/components/SendFlow/components/ReviewScreen.tsx
@@ -13,17 +13,14 @@ import {
 
 import { TxIdWithNotification } from '../../../../../2_molecules/TxIdWithNotification/TransactionIdWithNotification';
 import { translations } from '../../../../../../locales/i18n';
-import {
-  getBtcExplorerUrl,
-  getRskExplorerUrl,
-} from '../../../../../../utils/helpers';
+import { getBtcExplorerUrl } from '../../../../../../utils/helpers';
 import { formatValue } from '../../../../../../utils/math';
 import { useSendFlowContext } from '../../../contexts/sendflow';
+import { useChainDetails } from '../../../hooks/useChainDetails';
 import { useRuneBridgeLocked } from '../../../hooks/useRuneBridgeLocked';
 
 const translation = translations.runeBridge.send.confirmationScreens;
 
-const rskExplorerUrl = getRskExplorerUrl();
 const btcExplorerUrl = getBtcExplorerUrl();
 
 type FeesPaid = {
@@ -50,7 +47,7 @@ export const ReviewScreen: React.FC<ReviewScreenProps> = ({
 }) => {
   const runeBridgeLocked = useRuneBridgeLocked();
   const { selectedToken } = useSendFlowContext();
-
+  const { explorerUrl, baseCurrency } = useChainDetails();
   const items = useMemo(
     () => [
       {
@@ -58,7 +55,7 @@ export const ReviewScreen: React.FC<ReviewScreenProps> = ({
         value: (
           <TxIdWithNotification
             value={from}
-            href={`${rskExplorerUrl}/address/${from}`}
+            href={`${explorerUrl}/address/${from}`}
           />
         ),
       },
@@ -84,7 +81,7 @@ export const ReviewScreen: React.FC<ReviewScreenProps> = ({
         value: (
           <>
             {formatValue(feesPaid.rune, 8)} {selectedToken.symbol} +{' '}
-            {formatValue(feesPaid.baseCurrency, 8)} BTC
+            {formatValue(feesPaid.baseCurrency, 8)} {baseCurrency}
           </>
         ),
       },
@@ -97,7 +94,17 @@ export const ReviewScreen: React.FC<ReviewScreenProps> = ({
         ),
       },
     ],
-    [amount, feesPaid, from, receiveAmount, selectedToken.symbol, to],
+    [
+      amount,
+      baseCurrency,
+      feesPaid.baseCurrency,
+      feesPaid.rune,
+      from,
+      receiveAmount,
+      selectedToken.symbol,
+      to,
+      explorerUrl,
+    ],
   );
 
   return (

--- a/apps/frontend/src/app/3_organisms/RuneBridgeDialog/components/SendFlow/components/StatusScreen.tsx
+++ b/apps/frontend/src/app/3_organisms/RuneBridgeDialog/components/SendFlow/components/StatusScreen.tsx
@@ -15,12 +15,10 @@ import {
 import { StatusIcon } from '../../../../../2_molecules/StatusIcon/StatusIcon';
 import { TxIdWithNotification } from '../../../../../2_molecules/TxIdWithNotification/TransactionIdWithNotification';
 import { translations } from '../../../../../../locales/i18n';
-import {
-  getBtcExplorerUrl,
-  getRskExplorerUrl,
-} from '../../../../../../utils/helpers';
+import { getBtcExplorerUrl } from '../../../../../../utils/helpers';
 import { formatValue } from '../../../../../../utils/math';
 import { useSendFlowContext } from '../../../contexts/sendflow';
+import { useChainDetails } from '../../../hooks/useChainDetails';
 
 const translation = translations.runeBridge.send.confirmationScreens;
 
@@ -35,7 +33,6 @@ const getTitle = (status: StatusType) => {
   }
 };
 
-const rskExplorerUrl = getRskExplorerUrl();
 const btcExplorerUrl = getBtcExplorerUrl();
 
 interface FeesPaid {
@@ -67,7 +64,7 @@ export const StatusScreen: React.FC<StatusScreenProps> = ({
   onRetry,
 }) => {
   const { selectedToken } = useSendFlowContext();
-
+  const { chainName, baseCurrency, explorerUrl } = useChainDetails();
   const items = useMemo(
     () => [
       {
@@ -75,7 +72,7 @@ export const StatusScreen: React.FC<StatusScreenProps> = ({
         value: (
           <TxIdWithNotification
             value={from}
-            href={`${rskExplorerUrl}/address/${from}`}
+            href={`${explorerUrl}/address/${from}`}
           />
         ),
       },
@@ -101,7 +98,7 @@ export const StatusScreen: React.FC<StatusScreenProps> = ({
         value: (
           <>
             {formatValue(feesPaid.rune, 8)} {selectedToken.symbol} +{' '}
-            {formatValue(feesPaid.baseCurrency, 8)} BTC
+            {formatValue(feesPaid.baseCurrency, 8)} {baseCurrency}
           </>
         ),
       },
@@ -114,11 +111,11 @@ export const StatusScreen: React.FC<StatusScreenProps> = ({
         ),
       },
       {
-        label: t(translation.hash),
+        label: t(translation.hash, { chainName }),
         value: txHash ? (
           <TxIdWithNotification
             value={txHash}
-            href={`${rskExplorerUrl}/tx/${txHash}`}
+            href={`${explorerUrl}/tx/${txHash}`}
           />
         ) : (
           <Icon icon={IconNames.PENDING} />
@@ -137,7 +134,19 @@ export const StatusScreen: React.FC<StatusScreenProps> = ({
       //   ),
       // },
     ],
-    [amount, feesPaid, from, receiveAmount, selectedToken.symbol, to, txHash],
+    [
+      amount,
+      baseCurrency,
+      feesPaid.baseCurrency,
+      feesPaid.rune,
+      from,
+      receiveAmount,
+      selectedToken.symbol,
+      chainName,
+      to,
+      txHash,
+      explorerUrl,
+    ],
   );
 
   const status = useMemo(() => {

--- a/apps/frontend/src/app/3_organisms/RuneBridgeDialog/constants.ts
+++ b/apps/frontend/src/app/3_organisms/RuneBridgeDialog/constants.ts
@@ -9,3 +9,13 @@ export const MIN_POSTAGE_BTC = MIN_POSTAGE_SATS / 1e8;
 export const GAS_LIMIT_RUNE_BRIDGE_WITHDRAW = 200000;
 
 export const ORD_WALLET_LINK = 'https://github.com/ordinals/ord';
+
+export const DEPOSIT_ADDRESS_PATH = 'deposit-addresses/';
+
+export const LAST_SCANNED_BTC_BLOCK_PATH = 'last-scanned-btc-block/';
+
+export const DEPOSITS_PATH = 'deposits';
+
+export const RUNES_RSK_BRIDGE_NAME = 'runes';
+
+export const RUNES_BOB_BRIDGE_NAME = 'runesbob';

--- a/apps/frontend/src/app/3_organisms/RuneBridgeDialog/contextproviders/ReceiveFlowContext.tsx
+++ b/apps/frontend/src/app/3_organisms/RuneBridgeDialog/contextproviders/ReceiveFlowContext.tsx
@@ -1,12 +1,13 @@
 import React, { useCallback } from 'react';
 
-import { runeBridgeApiClient } from '../api';
 import { RequestOpts } from '../api/RuneBridgeClient';
+import { DEPOSITS_PATH, LAST_SCANNED_BTC_BLOCK_PATH } from '../constants';
 import {
   ReceiveFlowContext,
   defaultValue,
   ReceiveFlowContextStateType,
 } from '../contexts/receiveflow';
+import { useRuneBridgeApiClient } from '../hooks/useRuneBridgeApiClient';
 
 export type ReceiveFlowContextProviderProps = {
   children: React.ReactNode;
@@ -17,22 +18,25 @@ export const ReceiveFlowContextProvider: React.FC<
 > = ({ children }) => {
   const [state, setState] =
     React.useState<ReceiveFlowContextStateType>(defaultValue);
+  const runeBridgeApiClient = useRuneBridgeApiClient();
   const requestLastScannedBlock = useCallback(async () => {
-    const path = '/runes/last-scanned-btc-block/';
     const reqOptions: RequestOpts = {
       method: 'GET',
     };
-    return await runeBridgeApiClient.request(path, reqOptions);
-  }, []);
+    return await runeBridgeApiClient.request(
+      LAST_SCANNED_BTC_BLOCK_PATH,
+      reqOptions,
+    );
+  }, [runeBridgeApiClient]);
   const getRuneDepositStatus = useCallback(
     async (userEvmAddress: string, lastScannedBlockHash: string) => {
-      const path = `/runes/deposits/${userEvmAddress}/${lastScannedBlockHash}`;
+      const path = `${DEPOSITS_PATH}/${userEvmAddress}/${lastScannedBlockHash}`;
       const reqOptions: RequestOpts = {
         method: 'GET',
       };
       return await runeBridgeApiClient.request(path, reqOptions);
     },
-    [],
+    [runeBridgeApiClient],
   );
   const value = React.useMemo(
     () => ({

--- a/apps/frontend/src/app/3_organisms/RuneBridgeDialog/contextproviders/RuneContextProvider.tsx
+++ b/apps/frontend/src/app/3_organisms/RuneBridgeDialog/contextproviders/RuneContextProvider.tsx
@@ -23,10 +23,9 @@ export const RuneContextProvider: React.FC<RuneContextProviderProps> = ({
   children,
 }) => {
   const [state, setState] = React.useState<RuneContextStateType>(defaultValue);
-
-  const { provider, account } = useAccount();
-  const runeBridgeContract = useGetProtocolContract('runeBridge');
   const chainId = useCurrentChain();
+  const { provider, account } = useAccount();
+  const runeBridgeContract = useGetProtocolContract('runeBridge', chainId);
 
   const { value: listTokens } = useCacheCall(
     'runeBridge/tokens',

--- a/apps/frontend/src/app/3_organisms/RuneBridgeDialog/hooks/useChainDetails.ts
+++ b/apps/frontend/src/app/3_organisms/RuneBridgeDialog/hooks/useChainDetails.ts
@@ -1,0 +1,45 @@
+import React from 'react';
+
+import { BITCOIN, ETH } from '../../../../constants/currencies';
+import { useCurrentChain } from '../../../../hooks/useChainStore';
+import { isRskChain, isBobChain, getChainById } from '../../../../utils/chain';
+import {
+  getRskExplorerUrl,
+  getBobExplorerUrl,
+} from '../../../../utils/helpers';
+
+export type ChainDetails = {
+  supported: boolean;
+  chainName: string;
+  baseCurrency: string;
+  explorerUrl: string;
+};
+
+export const useChainDetails = (): ChainDetails => {
+  const chainId = useCurrentChain();
+  return React.useMemo(() => {
+    if (isRskChain(chainId)) {
+      return {
+        supported: true,
+        chainName: 'Rootstock',
+        baseCurrency: BITCOIN,
+        explorerUrl: getRskExplorerUrl(),
+      };
+    } else if (isBobChain(chainId)) {
+      return {
+        supported: true,
+        chainName: 'BoB',
+        baseCurrency: ETH,
+        explorerUrl: getBobExplorerUrl(),
+      };
+    } else {
+      const chain = getChainById(chainId);
+      return {
+        supported: false,
+        chainName: chain?.label || 'Unknown',
+        baseCurrency: chain?.token || 'Unknown',
+        explorerUrl: chain?.blockExplorerUrl || '',
+      };
+    }
+  }, [chainId]);
+};

--- a/apps/frontend/src/app/3_organisms/RuneBridgeDialog/hooks/useRequestDepositAddress.tsx
+++ b/apps/frontend/src/app/3_organisms/RuneBridgeDialog/hooks/useRequestDepositAddress.tsx
@@ -1,30 +1,32 @@
 import React from 'react';
 
 import { useAccount } from '../../../../hooks/useAccount';
-import { runeBridgeApiClient } from '../api';
 import { RequestOpts } from '../api/RuneBridgeClient';
+import { DEPOSIT_ADDRESS_PATH } from '../constants';
 import { useRuneContext } from '../contexts/rune';
+import { useRuneBridgeApiClient } from './useRuneBridgeApiClient';
 
 export const useRequestDepositAddress = () => {
   const { account } = useAccount();
   const { set } = useRuneContext();
-
+  const runeBridgeApiClient = useRuneBridgeApiClient();
   return React.useCallback(async () => {
-    const url = '/runes/deposit-addresses/';
     const data = { evm_address: account };
     const requestOps: RequestOpts = {
       method: 'POST',
       data,
     };
-    return await runeBridgeApiClient.request(url, requestOps).then(response => {
-      const { deposit_address: depositAddress } = response;
-      set(prevState => {
-        return {
-          ...prevState,
-          depositAddress,
-        };
+    return await runeBridgeApiClient
+      .request(DEPOSIT_ADDRESS_PATH, requestOps)
+      .then(response => {
+        const { deposit_address: depositAddress } = response;
+        set(prevState => {
+          return {
+            ...prevState,
+            depositAddress,
+          };
+        });
+        return response;
       });
-      return response;
-    });
-  }, [account, set]);
+  }, [account, runeBridgeApiClient, set]);
 };

--- a/apps/frontend/src/app/3_organisms/RuneBridgeDialog/hooks/useRuneBridgeApiClient.ts
+++ b/apps/frontend/src/app/3_organisms/RuneBridgeDialog/hooks/useRuneBridgeApiClient.ts
@@ -1,0 +1,19 @@
+import React from 'react';
+
+import { useCurrentChain } from '../../../../hooks/useChainStore';
+import { isBobChain } from '../../../../utils/chain';
+import { currentNetwork } from '../../../../utils/helpers';
+import RuneBridgeClient from '../api/RuneBridgeClient';
+import { endpoints } from '../config';
+import { RUNES_BOB_BRIDGE_NAME, RUNES_RSK_BRIDGE_NAME } from '../constants';
+
+export const useRuneBridgeApiClient = () => {
+  const chainId = useCurrentChain();
+  return React.useMemo(() => {
+    const suffix = isBobChain(chainId)
+      ? RUNES_BOB_BRIDGE_NAME
+      : RUNES_RSK_BRIDGE_NAME;
+    const baseUrl = `${endpoints[currentNetwork]}/api/v1/${suffix}`;
+    return new RuneBridgeClient(baseUrl);
+  }, [chainId]);
+};

--- a/apps/frontend/src/app/3_organisms/RuneBridgeDialog/hooks/useRuneBridgeLocked.ts
+++ b/apps/frontend/src/app/3_organisms/RuneBridgeDialog/hooks/useRuneBridgeLocked.ts
@@ -1,6 +1,21 @@
+import React from 'react';
+
+import { useCurrentChain } from '../../../../hooks/useChainStore';
 import { useMaintenance } from '../../../../hooks/useMaintenance';
+import { isBobChain } from '../../../../utils/chain';
 
 export const useRuneBridgeLocked = () => {
   const { checkMaintenance, States } = useMaintenance();
-  return checkMaintenance(States.D2_RUNE_BRIDGE_RSK);
+  const chainId = useCurrentChain();
+  return React.useMemo(() => {
+    const currentState = isBobChain(chainId)
+      ? States.D2_RUNE_BRIDGE_BOB
+      : States.D2_RUNE_BRIDGE_RSK;
+    return checkMaintenance(currentState);
+  }, [
+    States.D2_RUNE_BRIDGE_BOB,
+    States.D2_RUNE_BRIDGE_RSK,
+    chainId,
+    checkMaintenance,
+  ]);
 };

--- a/apps/frontend/src/app/3_organisms/TransactionStepDialog/TransactionStepDialog.types.ts
+++ b/apps/frontend/src/app/3_organisms/TransactionStepDialog/TransactionStepDialog.types.ts
@@ -8,6 +8,7 @@ import {
   ethers,
 } from 'ethers';
 
+import { AssetDetailsData } from '@sovryn/contracts';
 import { PermitTransactionResponse } from '@sovryn/sdk';
 import { StatusType } from '@sovryn/ui';
 
@@ -80,7 +81,7 @@ export type SignPermitRequest = {
 export type SignTransactionRequest = {
   type: TransactionType.signTransaction;
   contract: ethers.Contract;
-  tokenDetails?: TokenDetails;
+  assetDetailsData?: AssetDetailsData;
   fnName: string;
   args: any[];
   value?: BigNumberish;
@@ -116,10 +117,3 @@ export type TransactionReceipt = {
   request: TransactionRequest;
   response?: string | PermitTransactionResponse;
 };
-
-// should be kept compatible with AssetDetails from @sovryn/contracts
-export interface TokenDetails {
-  address: string;
-  symbol: string;
-  decimals: number;
-}

--- a/apps/frontend/src/app/3_organisms/TransactionStepDialog/components/TransactionStep/TransactionStep.tsx
+++ b/apps/frontend/src/app/3_organisms/TransactionStepDialog/components/TransactionStep/TransactionStep.tsx
@@ -78,18 +78,18 @@ export const TransactionStep: FC<TransactionStepProps> = ({
   useEffect(() => {
     const updateToken = (address: string) => {
       //FIXME: this logic needs to be updated to handle new typings, and matched with fixes to TransactionStepDialog.types.ts
-      //   if (isTransactionRequest(request) && request.tokenDetails) {
-      //     if (request.tokenDetails.address === address) {
-      //       setToken(request.tokenDetails);
-      //       return;
-      //     } else {
-      //       console.warn(
-      //         "Supplied token details address %s doesn't match address %s",
-      //         request.tokenDetails.address,
-      //         address,
-      //       );
-      //     }
-      //   }
+      if (isTransactionRequest(request) && request.assetDetailsData) {
+        if (request.assetDetailsData.address === address) {
+          setToken(request.assetDetailsData);
+          return;
+        } else {
+          console.warn(
+            "Supplied token details address %s doesn't match address %s",
+            request.assetDetailsData.address,
+            address,
+          );
+        }
+      }
       findContract(address, chainId)
         .then(result => {
           if (result.group === 'assets') {

--- a/apps/frontend/src/locales/en/translations.json
+++ b/apps/frontend/src/locales/en/translations.json
@@ -1008,9 +1008,9 @@
             "title": "Rune Bridge",
             "tabs": {
                 "receiveLabel": "Receive",
-                "receiveInfoText": "Transfer Runes from Bitcoin to your Rootstock address",
+                "receiveInfoText": "Transfer Runes from Bitcoin to your {{chainName}} address",
                 "sendLabel": "Send",
-                "sendInfoText": "Transfer Rune Tokens from Rootstock to your Bitcoin address"
+                "sendInfoText": "Transfer Rune Tokens from {{chainName}} to your Bitcoin address"
             }
         },
         "instructions": {
@@ -1064,7 +1064,7 @@
                 "sending": "Sending",
                 "serviceFee": "Service fee",
                 "receiving": "Receiving",
-                "hash": "Rootstock TXID",
+                "hash": "{{chainName}} TXID",
                 "bitcoinTxId": "Bitcoin TXID"
             },
             "txDialog": {
@@ -1079,8 +1079,8 @@
                 "transferStatus": {
                     "detected": "Transfer detected",
                     "seen": "Runes received by the bridge",
-                    "sent_to_evm": "Rune Tokens transferred in Rootstock",
-                    "confirmed": "Rune Token transfer confirmed in Rootstock"
+                    "sent_to_evm": "Rune Tokens transferred in {{chainName}}",
+                    "confirmed": "Rune Token transfer confirmed in {{chainName}}"
                 },
                 "statusTitleProcessing": "Transfer processing...",
                 "statusTitleComplete": "Transfer complete",
@@ -1089,7 +1089,8 @@
                 "serviceFee": "Service fee",
                 "receiving": "Receiving",
                 "bitcoinTxId": "Bitcoin TXID",
-                "rootstockTxId": "Rootstock TXID"
+                "rootstockTxId": "Rootstock TXID",
+                "currentChainTxId": "{{chainName}} TXID"
             }
         }
     },

--- a/apps/frontend/src/utils/helpers.ts
+++ b/apps/frontend/src/utils/helpers.ts
@@ -18,6 +18,7 @@ import {
   GRAPH_WRAPPER,
   SERVICES_CONFIG,
 } from '../constants/infrastructure';
+import { BOB } from '../constants/infrastructure/bob';
 import { BTC } from '../constants/infrastructure/btc';
 import { RSK } from '../constants/infrastructure/rsk';
 import { ALPHA_LINKS, BITOCRACY_LINKS, GITHUB_LINKS } from '../constants/links';
@@ -57,6 +58,9 @@ export const getServicesConfig = () =>
 
 export const getRskExplorerUrl = () =>
   RSK.explorer[isMainnet() ? 'mainnet' : 'testnet'];
+
+export const getBobExplorerUrl = () =>
+  BOB.explorer[isMainnet() ? 'mainnet' : 'testnet'];
 
 export const getBtcExplorerUrl = () =>
   BTC.explorer[isMainnet() ? 'mainnet' : 'testnet'];

--- a/packages/contracts/src/contracts/protocol/bob.ts
+++ b/packages/contracts/src/contracts/protocol/bob.ts
@@ -11,7 +11,7 @@ export const bob: Record<string, AsyncContractConfigData> = {
       (await import('../../abis/merkleDistributor.json')).default,
   },
   runeBridge: {
-    address: '',
+    address: '0x8989E07E565966463C73dadE4c095DaC991e1dD2',
     getAbi: async () => (await import('../../abis/RuneBridge.json')).default,
   },
 };

--- a/packages/contracts/src/contracts/protocol/bobTestnet.ts
+++ b/packages/contracts/src/contracts/protocol/bobTestnet.ts
@@ -11,7 +11,7 @@ export const bobTestnet: Record<string, AsyncContractConfigData> = {
       (await import('../../abis/merkleDistributor.json')).default,
   },
   runeBridge: {
-    address: '',
+    address: '0x9d451acb7A7f98dc4F2d2A2aA1A0b0436f0Effdb',
     getAbi: async () => (await import('../../abis/RuneBridge.json')).default,
   },
 };


### PR DESCRIPTION
* resolve FIXME, use AssetDetailsData instead of custom one.

* Add translation context and provider in RuneBridge to handle text translation when switching chains.

* Add the runeBridge contract address on the Bob testnet.

* Fix issue: couldn't fetch runeBridge contract on Bob testnet.

* utilize useTranslationContext instead of create new useContext. revert postage content to default instead of using cryptoDenomination param. using coinAbbreviation for some views such as ReviewScreen, StatusScreen. This will ensure the display text corresponding to the current connected chain.

* Fix Maximum update depth exceeded error.

* Enhanced the useRuneBridgeLocked hook to support multi-chain environments by integrating the useCurrentChain hook.

* useRuneBridgeLocked: optimize the logic.

* Move and use API path from constants.ts runeBridgeApiClient add setter and getter for baseUrl, and update baseUrl depend on current chain.

* Remove baseUrl getter. use isBobChain from utils to avoid duplication code.

* Add useRuneBridgeApiClient hook. Remove index.ts file which is no longer needed.
remove setter from RuneBridgeClient.

* satoshi as unit is lower case

* Change runeBridgeApiClient name to uppercase load path constants instead of hardcode string

* Loads of changes

- Get rid of TranslationContext, not needed
- Correct explorer urls
- Hide the dialog for unsupported chains
- Refactoring
- Some more stuff

* Fix dialog for unsupported chains

* Bob mainnet address

* Rename BoB mainnet exported constant to bob (from bobTestnet)

* Improve copy for unsupported networks

* Fix useGetProtocolContract calls and base currency

* Resolve conversations!

---------

https://sovryn.atlassian.net/browse/SOV-4023