### PR TITLE
fix(sdk): Ambient route encodes slippage 10x looser than selected (bps treated as per-mille)

### DIFF
--- a/.changeset/ambient-slippage-basis-points.md
+++ b/.changeset/ambient-slippage-basis-points.md
@@ -1,0 +1,5 @@
+---
+'@sovryn/sdk': patch
+---
+
+Fix Ambient route slippage encoding: `options.slippage` is expressed in basis points (10_000 = 100%) but was divided by 1000 instead of 10000 before being passed to sdex, so the enforced slippage bound was 10x looser than the value the user selected (e.g. 0.5% became 5%). The fallback default now uses the shared `DEFAULT_SWAP_SLIPPAGE` constant (1%).

--- a/.changeset/ambient-slippage-basis-points.md
+++ b/.changeset/ambient-slippage-basis-points.md
@@ -2,4 +2,4 @@
 '@sovryn/sdk': patch
 ---
 
-Fix Ambient route slippage encoding: `options.slippage` is expressed in basis points (10_000 = 100%) but was divided by 1000 instead of 10000 before being passed to sdex, so the enforced slippage bound was 10x looser than the value the user selected (e.g. 0.5% became 5%). The fallback default now uses the shared `DEFAULT_SWAP_SLIPPAGE` constant (1%).
+Fix Ambient route slippage encoding: `options.slippage` is expressed in basis points (10_000 = 100%) but was divided by 1000 instead of 10000 before being passed to sdex, so the enforced slippage bound was 10x looser than the value the user selected (e.g. 0.5% became 5%). The `?? 50` fallback keeps its intended meaning of 0.5%, matching the UI's preset tolerance.

--- a/packages/sdk/src/_tests/swaps/routes/ambient-route.test.ts
+++ b/packages/sdk/src/_tests/swaps/routes/ambient-route.test.ts
@@ -1,0 +1,94 @@
+import { BigNumber, constants, providers } from 'ethers';
+
+import { DEFAULT_SWAP_SLIPPAGE } from '../../../constants';
+import { getMinReturn } from '../../../internal/utils';
+import { ambientRoute } from '../../../swaps/smart-router/routes/ambient';
+import { SwapRoute } from '../../../swaps/smart-router/types';
+
+const BOB_MAINNET_CHAIN_ID = 60808;
+
+const mockTokenA = '0x00000000000000000000000000000000000000aa';
+const mockTokenB = '0x00000000000000000000000000000000000000bb';
+const mockZeroAddress = '0x0000000000000000000000000000000000000000';
+
+// captures the slippage options handed to sdex's CrocEnv swap plans
+const mockCapturedSlippages: number[] = [];
+
+jest.mock('@sovryn/sdex', () => ({
+  CrocEnv: jest.fn().mockImplementation(() => ({
+    context: Promise.resolve({
+      dex: { address: mockZeroAddress },
+      chain: { proxyPaths: { long: 0 } },
+    }),
+    tokens: {
+      materialize: () => ({ decimals: 18 }),
+    },
+    sell: () => ({
+      for: (_destination: string, opts: { slippage?: number }) => {
+        if (opts.slippage !== undefined) {
+          mockCapturedSlippages.push(opts.slippage);
+        }
+        return {
+          generateSwapData: async () => ({
+            to: mockZeroAddress,
+            data: '0x',
+            value: '0',
+          }),
+        };
+      },
+    }),
+  })),
+}));
+
+jest.mock('../../../swaps/smart-router/utils/ambient-utils', () => ({
+  ...jest.requireActual('../../../swaps/smart-router/utils/ambient-utils'),
+  fetchPools: async () => [[mockTokenA, mockTokenB, 400]],
+}));
+
+describe('Ambient route slippage encoding', () => {
+  let route: SwapRoute;
+
+  const provider = {
+    getNetwork: async () => ({ chainId: BOB_MAINNET_CHAIN_ID }),
+  } as providers.Provider;
+
+  const swapWithSlippage = async (slippage?: number) => {
+    mockCapturedSlippages.length = 0;
+    await route.swap(
+      mockTokenA,
+      mockTokenB,
+      constants.WeiPerEther,
+      constants.AddressZero,
+      slippage !== undefined ? { slippage } : undefined,
+    );
+    expect(mockCapturedSlippages).toHaveLength(1);
+    return mockCapturedSlippages[0];
+  };
+
+  beforeEach(() => {
+    route = ambientRoute(provider);
+  });
+
+  it('encodes basis points as the fraction sdex expects (50 bps -> 0.005)', async () => {
+    const fraction = await swapWithSlippage(50);
+    expect(fraction).toBeCloseTo(0.005, 10);
+  });
+
+  it('defaults to DEFAULT_SWAP_SLIPPAGE when no slippage option is given', async () => {
+    const fraction = await swapWithSlippage();
+    expect(fraction).toBeCloseTo(DEFAULT_SWAP_SLIPPAGE / 10000, 10);
+  });
+
+  it('matches getMinReturn basis-point semantics across tolerance values', async () => {
+    for (const bps of [10, 50, 100, 1000]) {
+      const fraction = await swapWithSlippage(bps);
+
+      const minReturn = getMinReturn(constants.WeiPerEther, bps);
+      const impliedMinReturn = BigNumber.from(
+        BigInt(Math.round((1 - fraction) * 1e18)).toString(),
+      );
+
+      expect(impliedMinReturn.toString()).toEqual(minReturn.toString());
+    }
+  });
+});

--- a/packages/sdk/src/_tests/swaps/routes/ambient-route.test.ts
+++ b/packages/sdk/src/_tests/swaps/routes/ambient-route.test.ts
@@ -1,5 +1,7 @@
 import { BigNumber, constants, providers } from 'ethers';
 
+import { OrderDirective } from '@sovryn/sdex/dist/encoding/longform';
+
 import { DEFAULT_SWAP_SLIPPAGE } from '../../../constants';
 import { getMinReturn } from '../../../internal/utils';
 import { ambientRoute } from '../../../swaps/smart-router/routes/ambient';
@@ -9,7 +11,15 @@ const BOB_MAINNET_CHAIN_ID = 60808;
 
 const mockTokenA = '0x00000000000000000000000000000000000000aa';
 const mockTokenB = '0x00000000000000000000000000000000000000bb';
+// sorts below A and B so the second hop of A -> B -> C is a sell leg
+const mockTokenC = '0x0000000000000000000000000000000000000011';
 const mockZeroAddress = '0x0000000000000000000000000000000000000000';
+
+// Q64.64 sqrt price of 1.0, i.e. 2^64
+const mockUnitSqrtPrice = '18446744073709551616';
+
+// pools returned by the mocked indexer; tests may override per case
+let mockPools: [string, string, number][] = [[mockTokenA, mockTokenB, 400]];
 
 // captures the slippage options handed to sdex's CrocEnv swap plans
 const mockCapturedSlippages: number[] = [];
@@ -17,11 +27,23 @@ const mockCapturedSlippages: number[] = [];
 jest.mock('@sovryn/sdex', () => ({
   CrocEnv: jest.fn().mockImplementation(() => ({
     context: Promise.resolve({
-      dex: { address: mockZeroAddress },
-      chain: { proxyPaths: { long: 0 } },
+      dex: {
+        address: mockZeroAddress,
+        interface: { encodeFunctionData: () => '0x' },
+      },
+      chain: { proxyPaths: { long: 130 } },
     }),
     tokens: {
       materialize: () => ({ decimals: 18 }),
+    },
+    pool: async (tokenA: string, tokenB: string, poolIndex: number) => {
+      const [base, quote] =
+        tokenA < tokenB ? [tokenA, tokenB] : [tokenB, tokenA];
+      return {
+        baseToken: { tokenAddr: base },
+        quoteToken: { tokenAddr: quote },
+        poolIndex,
+      };
     },
     sell: () => ({
       for: (_destination: string, opts: { slippage?: number }) => {
@@ -42,7 +64,12 @@ jest.mock('@sovryn/sdex', () => ({
 
 jest.mock('../../../swaps/smart-router/utils/ambient-utils', () => ({
   ...jest.requireActual('../../../swaps/smart-router/utils/ambient-utils'),
-  fetchPools: async () => [[mockTokenA, mockTokenB, 400]],
+  fetchPools: async () => mockPools,
+  calcImpact: async () => ({
+    finalPrice: mockUnitSqrtPrice,
+    baseFlow: '1000000000000000000',
+    quoteFlow: '-1000000000000000000',
+  }),
 }));
 
 describe('Ambient route slippage encoding', () => {
@@ -66,6 +93,7 @@ describe('Ambient route slippage encoding', () => {
   };
 
   beforeEach(() => {
+    mockPools = [[mockTokenA, mockTokenB, 400]];
     route = ambientRoute(provider);
   });
 
@@ -90,5 +118,38 @@ describe('Ambient route slippage encoding', () => {
 
       expect(impliedMinReturn.toString()).toEqual(minReturn.toString());
     }
+  });
+
+  it('bounds each multi-hop pool sqrt price by the same fraction (50 bps -> 1 +/- 0.005)', async () => {
+    mockPools = [
+      [mockTokenA, mockTokenB, 400],
+      [mockTokenC, mockTokenB, 410],
+    ];
+    route = ambientRoute(provider);
+
+    const appendPoolSpy = jest.spyOn(OrderDirective.prototype, 'appendPool');
+
+    // no direct A/C pool -> long-form multi-hop path A -> B -> C
+    await route.swap(
+      mockTokenA,
+      mockTokenC,
+      constants.WeiPerEther,
+      constants.AddressZero,
+      { slippage: 50 },
+    );
+
+    const orderPools = appendPoolSpy.mock.results.map(result => result.value);
+    appendPoolSpy.mockRestore();
+    expect(orderPools).toHaveLength(2);
+
+    // calcImpact is mocked to a sqrt price of exactly 1.0 (2^64), so the
+    // encoded limitPrice ratio is the applied sqrt-price slippage bound
+    const boundRatios = orderPools.map(
+      pool => Number(pool.swap.limitPrice.toString()) / 2 ** 64,
+    );
+
+    // first hop buys (entry is base), second hop sells (entry is quote)
+    expect(boundRatios[0]).toBeCloseTo(1.005, 6);
+    expect(boundRatios[1]).toBeCloseTo(0.995, 6);
   });
 });

--- a/packages/sdk/src/_tests/swaps/routes/ambient-route.test.ts
+++ b/packages/sdk/src/_tests/swaps/routes/ambient-route.test.ts
@@ -2,7 +2,6 @@ import { BigNumber, constants, providers } from 'ethers';
 
 import { OrderDirective } from '@sovryn/sdex/dist/encoding/longform';
 
-import { DEFAULT_SWAP_SLIPPAGE } from '../../../constants';
 import { getMinReturn } from '../../../internal/utils';
 import { ambientRoute } from '../../../swaps/smart-router/routes/ambient';
 import { SwapRoute } from '../../../swaps/smart-router/types';
@@ -102,9 +101,9 @@ describe('Ambient route slippage encoding', () => {
     expect(fraction).toBeCloseTo(0.005, 10);
   });
 
-  it('defaults to DEFAULT_SWAP_SLIPPAGE when no slippage option is given', async () => {
+  it('defaults to 50 bps (0.5%, the UI preset) when no slippage option is given', async () => {
     const fraction = await swapWithSlippage();
-    expect(fraction).toBeCloseTo(DEFAULT_SWAP_SLIPPAGE / 10000, 10);
+    expect(fraction).toBeCloseTo(0.005, 10);
   });
 
   it('matches getMinReturn basis-point semantics across tolerance values', async () => {

--- a/packages/sdk/src/swaps/smart-router/routes/ambient.ts
+++ b/packages/sdk/src/swaps/smart-router/routes/ambient.ts
@@ -6,6 +6,7 @@ import { CrocEnv, CrocPoolView } from '@sovryn/sdex';
 import { OrderDirective } from '@sovryn/sdex/dist/encoding/longform';
 import { Decimal } from '@sovryn/utils';
 
+import { DEFAULT_SWAP_SLIPPAGE } from '../../../constants';
 import { SovrynErrorCode, makeError } from '../../../errors/errors';
 import {
   hasEnoughAllowance,
@@ -230,7 +231,9 @@ export const ambientRoute: SwapRouteFunction = (
     },
     permit: async () => Promise.resolve(undefined),
     swap: async (entry, destination, amount, from, options, overrides) => {
-      const slippage = Number(options?.slippage ?? 50) / 1000;
+      // options.slippage is in basis points (10_000 = 100%); sdex expects a fraction
+      const slippage =
+        Number(options?.slippage ?? DEFAULT_SWAP_SLIPPAGE) / 10000;
 
       const pools = await loadPools();
       const chainId = await getChainId();

--- a/packages/sdk/src/swaps/smart-router/routes/ambient.ts
+++ b/packages/sdk/src/swaps/smart-router/routes/ambient.ts
@@ -6,7 +6,6 @@ import { CrocEnv, CrocPoolView } from '@sovryn/sdex';
 import { OrderDirective } from '@sovryn/sdex/dist/encoding/longform';
 import { Decimal } from '@sovryn/utils';
 
-import { DEFAULT_SWAP_SLIPPAGE } from '../../../constants';
 import { SovrynErrorCode, makeError } from '../../../errors/errors';
 import {
   hasEnoughAllowance,
@@ -231,9 +230,9 @@ export const ambientRoute: SwapRouteFunction = (
     },
     permit: async () => Promise.resolve(undefined),
     swap: async (entry, destination, amount, from, options, overrides) => {
-      // options.slippage is in basis points (10_000 = 100%); sdex expects a fraction
-      const slippage =
-        Number(options?.slippage ?? DEFAULT_SWAP_SLIPPAGE) / 10000;
+      // options.slippage is in basis points (10_000 = 100%); sdex expects a
+      // fraction. Fallback 50 bps = 0.5%, the UI's preset tolerance.
+      const slippage = Number(options?.slippage ?? 50) / 10000;
 
       const pools = await loadPools();
       const chainId = await getChainId();


### PR DESCRIPTION
## What

The smart-router passes `options.slippage` in **basis points** (10_000 = 100% — documented in `internal/utils.ts` `getMinReturn` and `constants.ts`; the frontend sends `tolerance% × 100`). The Ambient route divided that value by **1000** instead of **10000** before handing it to `@sovryn/sdex`, which consumes a plain **fraction** (0.01 = 1%).

Result: the slippage bound actually encoded into BOB swap calldata was **10× looser** than the tolerance the user selected and the UI displayed as *Minimum received*:

- default 0.5% tolerance → enforced as **5%** (single-pool min-out)
- multi-hop: the fraction bounds a Q64.64 **sqrt** price, so ≈ **+10.25% / −9.75%** by direction
- a user entering 10 (%) → `slippage = 1.0` → min-out of **0**

Present since the BOB launch (`0cfa22b0`, May 2024) and in released `@sovryn/sdk` ≤ 2.0.10. Reported via advisory GHSA-jx33-xg6c-px39 (filed under Sovryn-smart-contracts, but the defect lives here; no contracts affected — they faithfully enforce whatever the calldata says).

## Fix

- `ambient.ts`: divide by 10000. The `?? 50` no-option fallback is kept and now means what the author intended: **50 bps = 0.5%, matching the UI's preset tolerance** on both Sovryn AMM and Sovryn DEX on BOB. (The UI always passes an explicit value, so the fallback only affects direct SDK consumers.)
- New regression suite `ambient-route.test.ts` (4 tests, no network): mocks the sdex `CrocEnv` boundary and captures what the route actually hands over —
  - 50 bps → 0.005 on the single-pool path
  - no-option fallback → 0.005 (0.5%)
  - cross-check against `getMinReturn` bps semantics for 10/50/100/1000 bps
  - multi-hop: real `OrderDirective` encoder (spied), `calcImpact` mocked to a unit sqrt price → each pool's encoded `limitPrice` is `1 ± 0.005`, buy and sell legs
  - each test verified to fail against the old `/1000` divisor
- Changeset: `@sovryn/sdk` patch.

## Verification

- sdk jest suite 77/77 green; eslint clean; `tsc --noEmit` clean apart from a pre-existing `_tests/_fixtures/chain.ts` error already on `develop`
- ambient.ts line coverage 21% → 54%; every remaining uncovered line is outside the slippage flow (quote/pairs/approve, error paths)

## Follow-ups (not in this PR)

- Centralize bps→fraction conversion in the smart-router layer so routes can't each pick a divisor; consider a branded `BasisPoints` type
- Cross-route invariant test spanning all `SWAP_ROUTES`
- Clamp the Convert-page tolerance input (currently accepts up to 100%)