### PR TITLE
fix(husky): make pre-commit reliable from linked git worktrees

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,5 +1,15 @@
 #!/usr/bin/env sh
 . "$(dirname -- "$0")/_/husky.sh"
 
+# In linked git worktrees, git exports an absolute GIT_DIR to hooks. Child git
+# calls that run in package subdirectories (jest --onlyChanged, via turbo) then
+# treat their own cwd as the top of the working tree and report thousands of
+# phantom changed files, so unrelated suites run with broken module resolution.
+# Unset it so each git call rediscovers the repo from its cwd — correct in both
+# the main checkout and linked worktrees. GIT_INDEX_FILE stays exported so
+# partial commits (git commit <paths>) still expose the temporary index to
+# lint-staged.
+unset GIT_DIR GIT_WORK_TREE
+
 npx turbo run test:staged
 npx lint-staged


### PR DESCRIPTION
## What

Adds `unset GIT_DIR GIT_WORK_TREE` at the top of `.husky/pre-commit`, before `turbo run test:staged` and `lint-staged`.

## Why

During `git commit` in a **linked git worktree**, git exports an absolute `GIT_DIR` (`<main>/.git/worktrees/<name>`) into the hook environment. Every child git call that `jest --onlyChanged` (jest-changed-files) makes from a **package subdirectory** then treats that package dir as the top of the working tree — git skips upward discovery when `GIT_DIR` is set and no `GIT_WORK_TREE` is given.

Measured from `packages/ethers-provider` inside the hook: `git diff --name-only HEAD` reported **1667 phantom changed files** (plus 1937 bogus untracked/modified, including `node_modules`). Consequences:

- every package "detects changes", so unrelated suites run on each commit;
- module resolution crosses checkout boundaries (worktrees nest inside the main checkout, so node's ancestor walk falls through to the main checkout's `node_modules`), crashing frontend tests with a duplicate-React error: `Cannot read properties of null (reading 'useRef')` in the `packages/ui` Tooltip.

In the main checkout git exports no `GIT_DIR` to the hook (only a relative `GIT_INDEX_FILE`), which is why commits there were always fine.

With the vars unset, each child git call rediscovers the repo from its own cwd — correct in both the main checkout and linked worktrees. `GIT_INDEX_FILE` is deliberately **kept** so partial commits (`git commit <paths>`) still expose the temporary index to lint-staged.

## Verification

- **Worktree commit (previously crashed):** only the suite related to the staged file ran (sdk suite as positive control after touching an sdk test — 9/9 passed); all other packages reported "No tests found related to files changed since last commit"; lint-staged linted the staged `.ts`; commit succeeded.
- **Main-checkout commit:** behavior unchanged (the unset is a no-op there — `GIT_DIR` was never exported); hook passed in ~8 s.
- The commit in this PR was itself made from a fresh linked worktree through the fixed hook.

## Reviewer notes

- No change to `--onlyChanged` semantics or any package `test:staged` script; the hook is not weakened.
- Hooks always run with cwd = repo/worktree top, so the top-level `npx turbo` / `npx lint-staged` invocations are unaffected by the unset.

