### PR TITLE
feat(convert): warn on high slippage tolerance (>=5%), hard-cap input at 49%

### DIFF
--- a/apps/frontend/src/app/5_pages/ConvertPage/ConvertPage.slippage.test.ts
+++ b/apps/frontend/src/app/5_pages/ConvertPage/ConvertPage.slippage.test.ts
@@ -1,0 +1,70 @@
+import {
+  MAXIMUM_SLIPPAGE_TOLERANCE,
+  SLIPPAGE_TOLERANCE_WARNING_THRESHOLD,
+  isHighSlippageTolerance,
+  isInvalidSlippageTolerance,
+} from './ConvertPage.slippage';
+
+describe('ConvertPage slippage tolerance policy', () => {
+  it('warns above 5% and hard-caps at 49%', () => {
+    expect(SLIPPAGE_TOLERANCE_WARNING_THRESHOLD).toBe(5);
+    expect(MAXIMUM_SLIPPAGE_TOLERANCE).toBe(49);
+  });
+
+  describe('isHighSlippageTolerance', () => {
+    it('does not warn for the default tolerance', () => {
+      expect(isHighSlippageTolerance('0.5')).toBe(false);
+    });
+
+    it('does not warn at exactly 5%', () => {
+      expect(isHighSlippageTolerance('5')).toBe(false);
+    });
+
+    it('warns at 5.01%', () => {
+      expect(isHighSlippageTolerance('5.01')).toBe(true);
+    });
+
+    it('warns at 6%', () => {
+      expect(isHighSlippageTolerance('6')).toBe(true);
+    });
+
+    it('warns at 49%', () => {
+      expect(isHighSlippageTolerance('49')).toBe(true);
+    });
+
+    it('does not warn for an empty input', () => {
+      expect(isHighSlippageTolerance('')).toBe(false);
+    });
+  });
+
+  describe('isInvalidSlippageTolerance', () => {
+    it('allows the default tolerance', () => {
+      expect(isInvalidSlippageTolerance('0.5')).toBe(false);
+    });
+
+    it('allows 5.01% and 6% (warning only, swap still allowed)', () => {
+      expect(isInvalidSlippageTolerance('5.01')).toBe(false);
+      expect(isInvalidSlippageTolerance('6')).toBe(false);
+    });
+
+    it('allows exactly 49%', () => {
+      expect(isInvalidSlippageTolerance('49')).toBe(false);
+    });
+
+    it('blocks 49.01%', () => {
+      expect(isInvalidSlippageTolerance('49.01')).toBe(true);
+    });
+
+    it('blocks 50%', () => {
+      expect(isInvalidSlippageTolerance('50')).toBe(true);
+    });
+
+    it('blocks 100%', () => {
+      expect(isInvalidSlippageTolerance('100')).toBe(true);
+    });
+
+    it('allows an empty input', () => {
+      expect(isInvalidSlippageTolerance('')).toBe(false);
+    });
+  });
+});

--- a/apps/frontend/src/app/5_pages/ConvertPage/ConvertPage.slippage.test.ts
+++ b/apps/frontend/src/app/5_pages/ConvertPage/ConvertPage.slippage.test.ts
@@ -16,8 +16,12 @@ describe('ConvertPage slippage tolerance policy', () => {
       expect(isHighSlippageTolerance('0.5')).toBe(false);
     });
 
-    it('does not warn at exactly 5%', () => {
-      expect(isHighSlippageTolerance('5')).toBe(false);
+    it('does not warn just below 5%', () => {
+      expect(isHighSlippageTolerance('4.99')).toBe(false);
+    });
+
+    it('warns at exactly 5% (catches 5 typed instead of 0.5)', () => {
+      expect(isHighSlippageTolerance('5')).toBe(true);
     });
 
     it('warns at 5.01%', () => {

--- a/apps/frontend/src/app/5_pages/ConvertPage/ConvertPage.slippage.ts
+++ b/apps/frontend/src/app/5_pages/ConvertPage/ConvertPage.slippage.ts
@@ -4,8 +4,9 @@
 export const SLIPPAGE_TOLERANCE_WARNING_THRESHOLD = 5;
 export const MAXIMUM_SLIPPAGE_TOLERANCE = 49;
 
+// Inclusive: exactly 5 also warns, to catch 5 typed instead of 0.5.
 export const isHighSlippageTolerance = (value: string) =>
-  Number(value) > SLIPPAGE_TOLERANCE_WARNING_THRESHOLD;
+  Number(value) >= SLIPPAGE_TOLERANCE_WARNING_THRESHOLD;
 
 // The input's HTML max attribute does not block typed values, so values
 // above the cap must also be rejected here and block submission.

--- a/apps/frontend/src/app/5_pages/ConvertPage/ConvertPage.slippage.ts
+++ b/apps/frontend/src/app/5_pages/ConvertPage/ConvertPage.slippage.ts
@@ -1,0 +1,13 @@
+// Slippage tolerance input policy. Not to be confused with
+// MAXIMUM_ALLOWED_SLIPPAGE in ConvertPage.constants.ts, which gates the
+// quoted price impact of a swap, not the user-entered tolerance.
+export const SLIPPAGE_TOLERANCE_WARNING_THRESHOLD = 5;
+export const MAXIMUM_SLIPPAGE_TOLERANCE = 49;
+
+export const isHighSlippageTolerance = (value: string) =>
+  Number(value) > SLIPPAGE_TOLERANCE_WARNING_THRESHOLD;
+
+// The input's HTML max attribute does not block typed values, so values
+// above the cap must also be rejected here and block submission.
+export const isInvalidSlippageTolerance = (value: string) =>
+  Number(value) > MAXIMUM_SLIPPAGE_TOLERANCE;

--- a/apps/frontend/src/app/5_pages/ConvertPage/ConvertPage.tsx
+++ b/apps/frontend/src/app/5_pages/ConvertPage/ConvertPage.tsx
@@ -73,6 +73,11 @@ import {
   SMART_ROUTER_STABLECOINS,
   SWAP_ROUTES,
 } from './ConvertPage.constants';
+import {
+  MAXIMUM_SLIPPAGE_TOLERANCE,
+  isHighSlippageTolerance,
+  isInvalidSlippageTolerance,
+} from './ConvertPage.slippage';
 import { CategoryType } from './ConvertPage.types';
 import { AssetDropdownWithFilters } from './components/AssetDropdownWithFilters/AssetDropdownWithFilters';
 import { useConversionMaintenance } from './hooks/useConversionMaintenance';
@@ -181,6 +186,16 @@ const ConvertPage: FC = () => {
 
   const [slippageTolerance, setSlippageTolerance] = useState(
     DEFAULT_SLIPPAGE_TOLERANCE,
+  );
+
+  const isSlippageToleranceInvalid = useMemo(
+    () => isInvalidSlippageTolerance(slippageTolerance),
+    [slippageTolerance],
+  );
+
+  const isSlippageToleranceHigh = useMemo(
+    () => isHighSlippageTolerance(slippageTolerance),
+    [slippageTolerance],
   );
 
   const [priceInQuote, setPriceQuote] = useState(false);
@@ -539,6 +554,7 @@ const ConvertPage: FC = () => {
       Number(amount) > Number(maximumAmountToConvert) ||
       !destinationToken ||
       !route ||
+      isSlippageToleranceInvalid ||
       (isSlippageHigh && !slippageWarningAccepted),
     [
       isInMaintenance,
@@ -547,6 +563,7 @@ const ConvertPage: FC = () => {
       maximumAmountToConvert,
       destinationToken,
       route,
+      isSlippageToleranceInvalid,
       isSlippageHigh,
       slippageWarningAccepted,
     ],
@@ -867,8 +884,30 @@ const ConvertPage: FC = () => {
                   step="0.01"
                   decimalPrecision={2}
                   placeholder="0"
-                  max="100"
+                  max={MAXIMUM_SLIPPAGE_TOLERANCE}
+                  invalid={isSlippageToleranceInvalid}
                 />
+
+                {isSlippageToleranceInvalid ? (
+                  <ErrorBadge
+                    level={ErrorLevel.Critical}
+                    message={t(
+                      pageTranslations.form.invalidSlippageToleranceError,
+                      { max: MAXIMUM_SLIPPAGE_TOLERANCE },
+                    )}
+                    dataAttribute="convert-slippage-tolerance-error"
+                  />
+                ) : (
+                  isSlippageToleranceHigh && (
+                    <ErrorBadge
+                      level={ErrorLevel.Warning}
+                      message={t(
+                        pageTranslations.form.highSlippageToleranceWarning,
+                      )}
+                      dataAttribute="convert-slippage-tolerance-warning"
+                    />
+                  )
+                )}
               </div>
             </Accordion>
 

--- a/apps/frontend/src/locales/en/translations.json
+++ b/apps/frontend/src/locales/en/translations.json
@@ -432,7 +432,9 @@
             "quoteError": "No route found, please try another asset or a lower amount",
             "noAvailableTokens": "No available tokens",
             "swapValueWarning": "The swap value is significantly lower than expected due to market conditions or slippage.",
-            "slippageWarning": "I acknowledge the risk and confirm to proceed"
+            "slippageWarning": "I acknowledge the risk and confirm to proceed",
+            "highSlippageToleranceWarning": "High slippage tolerance: your transaction may be frontrun and result in an unfavorable trade",
+            "invalidSlippageToleranceError": "Slippage tolerance must be {{max}}% or less"
         },
         "txDialog": {
             "convertTitle": "Convert {{from}} to {{to}}",


### PR DESCRIPTION
## What

Tightens the slippage tolerance input on the Convert page:

- **Warning at >= 5%** (inclusive, so a fat-fingered `5` typed instead of `0.5` is flagged): amber `ErrorBadge` — *"High slippage tolerance: your transaction may be frontrun and result in an unfavorable trade"*. The swap remains allowed.
- **Hard cap at 49%**: values above 49 are a validation error — the input is flagged `invalid`, a critical `ErrorBadge` shows *"Slippage tolerance must be 49% or less"*, and the Confirm button is disabled. Enforced in logic (new `ConvertPage.slippage.ts` predicates), not just via the input's `max` attribute, because HTML `max` does not block typed values. The `max` attribute is also lowered from 100 to 49.
- Default stays `0.5` (`DEFAULT_SLIPPAGE_TOLERANCE` unchanged). The error state replaces the warning rather than stacking.

## Why

Follow-up to #1144 / advisory GHSA-jx33-xg6c-px39. With the Ambient bps encoding fixed, the input still accepted up to 100%, and a 100% tolerance encodes a zero minimum output — this closes that remaining top-of-range footgun. UI-only: the SDK and the unrelated price-impact gate (`MAXIMUM_ALLOWED_SLIPPAGE = 1.5`) are untouched.

## Notes for review

- Policy constants + predicates live in a small dependency-free module (`ConvertPage.slippage.ts`) so the boundaries are unit-testable; a comment there disambiguates it from `MAXIMUM_ALLOWED_SLIPPAGE` in `ConvertPage.constants.ts`.
- 15 boundary tests (`ConvertPage.slippage.test.ts`): 0.5 / 4.99 / empty → clean · 5 / 5.01 / 6 / 49 → warn, allowed · 49.01 / 50 / 100 → blocked. Full frontend suite green, eslint clean.
- All four UI states verified on the dev server (default clean · 5% warn · 49% warn · 50% blocked, Confirm disabled).
- New locale keys added to `en` only; `es` has no `convertPage` keys and falls back to `en`.