### PR TITLE
fix: canonicalize typed-data signature v-byte before forwarding on-chain (Permit2 flows failing for Frame/Ledger wallets)

### DIFF
--- a/.changeset/violet-eagles-recover.md
+++ b/.changeset/violet-eagles-recover.md
@@ -1,0 +1,5 @@
+---
+'frontend': patch
+---
+
+fix: normalize typed-data signature v-byte (0/1 -> 27/28) before on-chain use so Permit2 flows work with Frame, Ledger and other raw-recovery-id wallets

--- a/apps/frontend/src/app/3_organisms/TransactionStepDialog/components/TransactionSteps/TransactionSteps.tsx
+++ b/apps/frontend/src/app/3_organisms/TransactionStepDialog/components/TransactionSteps/TransactionSteps.tsx
@@ -23,6 +23,7 @@ import { translations } from '../../../../../locales/i18n';
 import { findNativeAsset } from '../../../../../utils/asset';
 import { sleep } from '../../../../../utils/helpers';
 import { fromWei, toWei } from '../../../../../utils/math';
+import { normalizeSignature } from '../../../../../utils/signature';
 import {
   Transaction,
   TransactionReceiptStatus,
@@ -265,10 +266,16 @@ export const TransactionSteps: FC<TransactionStepsProps> = ({
 
           await handleUpdates();
         } else if (isTypedDataRequest(request)) {
-          const signature = await request.signer._signTypedData(
-            request.domain,
-            request.types,
-            request.values,
+          // Wallets like Frame or ledger modules return v as 0/1; on-chain
+          // verifiers (Permit2's ecrecover) accept only 27/28, while the
+          // ethers verification below tolerates both — so canonicalize before
+          // the signature is stored and forwarded on-chain.
+          const signature = normalizeSignature(
+            await request.signer._signTypedData(
+              request.domain,
+              request.types,
+              request.values,
+            ),
           );
 
           const verifiedAddress = ethers.utils.verifyTypedData(

--- a/apps/frontend/src/utils/signature.test.ts
+++ b/apps/frontend/src/utils/signature.test.ts
@@ -1,0 +1,102 @@
+import { ethers } from 'ethers';
+
+import { normalizeSignature } from './signature';
+
+describe('utils/signature.ts', () => {
+  describe('normalizeSignature()', () => {
+    // Wallets that expose raw signer output (Frame, the onboard-ledger module,
+    // some WalletConnect/MPC wallets) return the recovery byte as 0/1 instead
+    // of 27/28. ethers' verifyTypedData tolerates both forms, but on-chain
+    // verifiers that feed v straight into ecrecover (Permit2's
+    // SignatureVerification) accept ONLY 27/28 — ecrecover returns the zero
+    // address for v=0/1 and the tx reverts with InvalidSignature (0x8baa579f).
+    // These cases pin that every wallet-returned form is canonicalized to
+    // 65-byte r||s||v with v ∈ {27, 28} before being sent on-chain.
+
+    const r =
+      '0x0d8bcec44c865f8f0dd7d3a480ad0eb80cd8fe3575b13d39f7e421ed7c859f00';
+    const s =
+      '0x3475d99336ce2bf26a5bc6e946769ecc1763cdbce8abf24add0800084e76fbe2';
+    const base = r + s.slice(2);
+
+    it('rewrites recovery-id form v=0x00 to v=0x1b (27)', () => {
+      expect(normalizeSignature(base + '00')).toBe(base + '1b');
+    });
+
+    it('rewrites recovery-id form v=0x01 to v=0x1c (28)', () => {
+      expect(normalizeSignature(base + '01')).toBe(base + '1c');
+    });
+
+    it('returns canonical v=0x1b signatures byte-for-byte unchanged', () => {
+      expect(normalizeSignature(base + '1b')).toBe(base + '1b');
+    });
+
+    it('returns canonical v=0x1c signatures byte-for-byte unchanged', () => {
+      expect(normalizeSignature(base + '1c')).toBe(base + '1c');
+    });
+
+    it('expands 64-byte EIP-2098 compact signatures to canonical 65 bytes', () => {
+      const canonical = base + '1b';
+      const compact = ethers.utils.splitSignature(canonical).compact;
+      expect(ethers.utils.hexDataLength(compact)).toBe(64);
+      expect(normalizeSignature(compact)).toBe(canonical);
+    });
+
+    it('throws on a malformed recovery byte instead of passing it through', () => {
+      expect(() => normalizeSignature(base + '05')).toThrow();
+    });
+
+    it('is a no-op for signatures produced by standard (MetaMask-style) signers', async () => {
+      const wallet = new ethers.Wallet(
+        '0x1111111111111111111111111111111111111111111111111111111111111111',
+      );
+      const domain = { name: 'Test', version: '1', chainId: 30 };
+      const types = {
+        Message: [{ name: 'content', type: 'string' }],
+      };
+      const values = { content: 'hello' };
+      const signature = await wallet._signTypedData(domain, types, values);
+      expect(normalizeSignature(signature)).toBe(signature);
+    });
+
+    it('repairs the exact Frame-wallet Permit2 signature that reverted on-chain (rsk tx 0xa53eef8b…0020b2)', () => {
+      // r/s/v and the signed values below are lifted verbatim from the failed
+      // closeNueTroveWithPermit2 calldata; the wallet (Frame) returned v=0x00.
+      // Replaying that tx with only this byte rewritten to 0x1b succeeds, so
+      // the normalized form must recover the original sender.
+      const signer = '0xdEd56Aef779B5b30845FF2cb7f1Fc6adC1169ded';
+      const normalized = normalizeSignature(base + '00');
+      const recovered = ethers.utils.verifyTypedData(
+        {
+          name: 'Permit2',
+          chainId: 30,
+          verifyingContract: '0x000000000022D473030F116dDEE9F6B43aC78BA3',
+        },
+        {
+          PermitTransferFrom: [
+            { name: 'permitted', type: 'TokenPermissions' },
+            { name: 'spender', type: 'address' },
+            { name: 'nonce', type: 'uint256' },
+            { name: 'deadline', type: 'uint256' },
+          ],
+          TokenPermissions: [
+            { name: 'token', type: 'address' },
+            { name: 'amount', type: 'uint256' },
+          ],
+        },
+        {
+          permitted: {
+            token: '0xc1411567d2670e24d9c4daaa7cda95686e1250aa',
+            amount: '0x015d094cf05b0b8a838e',
+          },
+          spender: '0x5B9dB4B8bdeF3e57323187a9AC2639C5DEe5FD39',
+          nonce: '0x019fd8ee9eaf',
+          deadline: 0x6a9c8680,
+        },
+        normalized,
+      );
+      expect(normalized.slice(-2)).toBe('1b');
+      expect(recovered).toBe(signer);
+    });
+  });
+});

--- a/apps/frontend/src/utils/signature.ts
+++ b/apps/frontend/src/utils/signature.ts
@@ -1,0 +1,18 @@
+import { ethers } from 'ethers';
+
+/**
+ * Canonicalizes a wallet-returned ECDSA signature to the 65-byte r||s||v hex
+ * form with v ∈ {27, 28} — the only encoding contracts that feed v straight
+ * into ecrecover (e.g. Permit2's SignatureVerification) accept.
+ *
+ * Wallets that expose raw signer output (Frame, the onboard-ledger module,
+ * some WalletConnect/MPC wallets) return v as the recovery id (0/1), and
+ * EIP-2098 signers return a 64-byte compact form. ethers' own verification
+ * helpers silently tolerate all of these, so a signature must be normalized
+ * with this function before it is sent on-chain, not just verified.
+ *
+ * Canonical signatures pass through byte-for-byte unchanged; a malformed
+ * recovery byte throws here, at signing time, instead of reverting on-chain.
+ */
+export const normalizeSignature = (signature: ethers.BytesLike): string =>
+  ethers.utils.joinSignature(ethers.utils.splitSignature(signature));


### PR DESCRIPTION
## Problem

Wallets that expose raw signer output — **Frame**, the first-party `@sovryn/onboard-ledger` module (which deliberately converts Ledger's v 27/28 down to 0/1), and some WalletConnect/MPC wallets — return EIP-712 signatures with the recovery byte as `0/1` instead of the canonical `27/28`.

The dapp's post-signing check (`ethers.utils.verifyTypedData`) silently tolerates that form, so signing appears to succeed — but the **raw** signature is then forwarded on-chain, where Permit2's `SignatureVerification` feeds `v` straight into `ecrecover`. For `v=0/1` ecrecover returns the zero address and the tx reverts with `InvalidSignature()` (`0x8baa579f`).

This breaks **every Permit2 flow** for affected wallets: Zero trove close/adjust/repay with DLLR, Stability Pool DLLR deposits, and the DLLR conversion route.

Real-world incident: [RSK tx 0xa53eef8b…0020b2](https://explorer.rootstock.io/tx/0xa53eef8b687f745c9b012f383310f3c38fc2a7e2113b371fa9f710c1050020b2) — `closeNueTroveWithPermit2` from a Frame wallet. Replaying it at its original block with **only the final signature byte rewritten `0x00 → 0x1b` succeeds**, proving all other protocol conditions were valid. The Permit2 at the canonical CREATE2 address on Rootstock is byte-identical to Uniswap's Ethereum deployment (modulo chain-id immutable), so no contract change is applicable.

## Fix

All typed-data signatures pass through a single chokepoint (`TransactionSteps.tsx`). Canonicalize there, before the signature is verified/stored/forwarded, via new `normalizeSignature()` (`utils/signature.ts` = `joinSignature(splitSignature(sig))`):

- `v = 0/1` → `27/28`
- 64-byte EIP-2098 compact → canonical 65-byte
- canonical signatures pass through **byte-for-byte unchanged** (no-op for MetaMask-style signers — covered by a live `_signTypedData` roundtrip test)
- malformed `v` throws at signing time instead of burning gas on a doomed tx

## Tests

8 regression tests pin all four v-byte cases, the compact form, the standard-signer no-op, and **the exact signature from the failed incident tx** (r/s/v + typed data lifted from calldata) recovering the original sender. Frontend suite 60/60 green; tsc + eslint clean; changeset included.