### PR TITLE
feat: Sovryn Perimeter Fee display on withdraw and close flows

### DIFF
--- a/.changeset/perimeter-fee-display.md
+++ b/.changeset/perimeter-fee-display.md
@@ -1,0 +1,5 @@
+---
+'frontend': minor
+---
+
+feat: Sovryn Perimeter Fee display on withdraw and close flows. Shows the fee rate, amount, and net "You will receive" on lending withdrawals, borrower exits, Zero collateral withdrawal/close, and the surplus claim. Gated purely on on-chain state and fail-hidden: nothing renders until governance activates the perimeter and charging is enabled, so current forms are unchanged until then.

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -28,3 +28,26 @@ jobs:
         cache: 'yarn'
     - run: yarn install
     - run: yarn test
+
+  # `yarn test` type-STRIPS: craco/jest go through babel, and craco.config.js
+  # runs ts-loader with transpileOnly. The only full type check in the whole
+  # pipeline happens during the production build, so a type error can pass the
+  # matrix above and fail at the Netlify deploy gate instead — which is exactly
+  # how a missing required prop reached a release branch.
+  #
+  # `tsc --noEmit` is NOT the check to use here: this repo pins TypeScript 4.8,
+  # which cannot even parse some dependencies' modern .d.ts syntax, so it fails
+  # on node_modules regardless of our own code. Building is the gate that works.
+  build:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v3
+    - name: Use Node.js
+      uses: actions/setup-node@v3
+      with:
+        node-version: 20.x
+        cache: 'yarn'
+    - run: yarn install
+    - run: yarn build

--- a/apps/frontend/src/app/2_molecules/ExitFeeRow/ExitFeeRow.test.tsx
+++ b/apps/frontend/src/app/2_molecules/ExitFeeRow/ExitFeeRow.test.tsx
@@ -85,6 +85,9 @@ describe('ExitFeeRow', () => {
         gross={Decimal.from(gross)}
         rateBps={rateBps as number}
         active={active as boolean}
+        // Every case here is a quote we DID obtain, which says nothing is
+        // charged — as opposed to the unavailable case below.
+        unknown={false}
         assetSymbol="DLLR"
       />,
     );

--- a/apps/frontend/src/app/2_molecules/ExitFeeRow/ExitFeeRow.test.tsx
+++ b/apps/frontend/src/app/2_molecules/ExitFeeRow/ExitFeeRow.test.tsx
@@ -94,43 +94,23 @@ describe('ExitFeeRow', () => {
     expect(container).toBeEmptyDOMElement();
   });
 
-  it('renders the unavailable row when the quote could not be obtained', () => {
+  it.each([
+    ['the quote could not be obtained', { unknown: true, loading: false }],
+    ['the quote is still loading', { unknown: false, loading: true }],
+  ])('renders nothing when %s', (_label, state) => {
+    // Fail-hidden. The chain charges nothing when it cannot quote and pays
+    // the gross, so the honest display is the form exactly as it was before
+    // the perimeter existed — not a row that hints at a fee it cannot name.
     const { container } = render(
       <ExitFeeRow
         gross={Decimal.from(100)}
-        rateBps={0}
-        active={false}
-        unknown
+        rateBps={50}
+        active
         assetSymbol="DLLR"
+        {...state}
       />,
     );
-    // The fail-open contract cannot tell "no fee" from "could not ask", so the
-    // UI must not answer for it. Absence of a row reads as "no fee"; this must
-    // render something.
-    expect(
-      container.querySelector('[data-layout-id="exit-fee-unavailable"]'),
-    ).toBeInTheDocument();
-    expect(
-      container.querySelector('[data-layout-id="exit-fee-net"]'),
-    ).not.toBeInTheDocument();
-  });
-
-  it('renders the unavailable row while the quote is still loading', () => {
-    const { container } = render(
-      <ExitFeeRow
-        gross={Decimal.from(100)}
-        rateBps={0}
-        active={false}
-        unknown={false}
-        loading
-        assetSymbol="DLLR"
-      />,
-    );
-    // A quote that has not arrived is not evidence of a zero fee. This is the
-    // case every consumer used to get wrong by dropping `loading`.
-    expect(
-      container.querySelector('[data-layout-id="exit-fee-unavailable"]'),
-    ).toBeInTheDocument();
+    expect(container).toBeEmptyDOMElement();
   });
 
   it('renders nothing when the surface is genuinely uncharged', () => {

--- a/apps/frontend/src/app/2_molecules/ExitFeeRow/ExitFeeRow.test.tsx
+++ b/apps/frontend/src/app/2_molecules/ExitFeeRow/ExitFeeRow.test.tsx
@@ -32,6 +32,7 @@ describe('ExitFeeRow', () => {
         gross={Decimal.from(100)}
         rateBps={50}
         active
+        unknown={false}
         assetSymbol="DLLR"
       />,
     );
@@ -49,6 +50,7 @@ describe('ExitFeeRow', () => {
         gross={Decimal.from(100)}
         rateBps={50}
         active
+        unknown={false}
         assetSymbol="DLLR"
       />,
     );
@@ -83,6 +85,58 @@ describe('ExitFeeRow', () => {
         gross={Decimal.from(gross)}
         rateBps={rateBps as number}
         active={active as boolean}
+        assetSymbol="DLLR"
+      />,
+    );
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it('renders the unavailable row when the quote could not be obtained', () => {
+    const { container } = render(
+      <ExitFeeRow
+        gross={Decimal.from(100)}
+        rateBps={0}
+        active={false}
+        unknown
+        assetSymbol="DLLR"
+      />,
+    );
+    // The fail-open contract cannot tell "no fee" from "could not ask", so the
+    // UI must not answer for it. Absence of a row reads as "no fee"; this must
+    // render something.
+    expect(
+      container.querySelector('[data-layout-id="exit-fee-unavailable"]'),
+    ).toBeInTheDocument();
+    expect(
+      container.querySelector('[data-layout-id="exit-fee-net"]'),
+    ).not.toBeInTheDocument();
+  });
+
+  it('renders the unavailable row while the quote is still loading', () => {
+    const { container } = render(
+      <ExitFeeRow
+        gross={Decimal.from(100)}
+        rateBps={0}
+        active={false}
+        unknown={false}
+        loading
+        assetSymbol="DLLR"
+      />,
+    );
+    // A quote that has not arrived is not evidence of a zero fee. This is the
+    // case every consumer used to get wrong by dropping `loading`.
+    expect(
+      container.querySelector('[data-layout-id="exit-fee-unavailable"]'),
+    ).toBeInTheDocument();
+  });
+
+  it('renders nothing when the surface is genuinely uncharged', () => {
+    const { container } = render(
+      <ExitFeeRow
+        gross={Decimal.from(100)}
+        rateBps={0}
+        active={false}
+        unknown={false}
         assetSymbol="DLLR"
       />,
     );

--- a/apps/frontend/src/app/2_molecules/ExitFeeRow/ExitFeeRow.test.tsx
+++ b/apps/frontend/src/app/2_molecules/ExitFeeRow/ExitFeeRow.test.tsx
@@ -1,0 +1,91 @@
+import { render, screen, fireEvent } from '@testing-library/react';
+
+import React from 'react';
+
+import 'jest-canvas-mock';
+
+import { Decimal } from '@sovryn/utils';
+
+import { i18n } from '../../../locales/i18n';
+import { ExitFeeRow } from './ExitFeeRow';
+
+jest.mock('nanoid', () => {
+  return { nanoid: () => '1234' };
+});
+
+jest.mock('../../../contexts/NotificationContext', () => {
+  return {
+    useNotificationContext: () => ({
+      addNotification: jest.fn(),
+    }),
+  };
+});
+
+describe('ExitFeeRow', () => {
+  beforeAll(async () => {
+    await i18n;
+  });
+
+  it('renders a single row with the net amount when the fee is active', () => {
+    const { container } = render(
+      <ExitFeeRow
+        gross={Decimal.from(100)}
+        rateBps={50}
+        active
+        assetSymbol="DLLR"
+      />,
+    );
+    expect(screen.getByText('You will receive')).toBeInTheDocument();
+    // "Perimeter fee" only lives inside the (closed) tooltip, not as a row label.
+    expect(screen.queryByText(/^Perimeter fee/)).not.toBeInTheDocument();
+    expect(
+      container.querySelector('[data-layout-id="exit-fee-net"]'),
+    ).toHaveTextContent('99.5');
+  });
+
+  it('shows the fee amount and disclaimer inside the tooltip on click', () => {
+    const { container } = render(
+      <ExitFeeRow
+        gross={Decimal.from(100)}
+        rateBps={50}
+        active
+        assetSymbol="DLLR"
+      />,
+    );
+
+    const helperIcon = container.querySelector(
+      '[data-layout-id="exit-fee-helper"]',
+    );
+    expect(helperIcon).toBeInTheDocument();
+    // tooltip content is not rendered until the trigger is clicked
+    expect(
+      screen.queryByText(/Perimeter fee \(0\.5%\)/),
+    ).not.toBeInTheDocument();
+
+    fireEvent.click(helperIcon as Element);
+
+    expect(screen.getByText(/Perimeter fee \(0\.5%\)/)).toBeInTheDocument();
+    expect(
+      screen.getByText(
+        /The perimeter fee is deducted from the withdrawn amount/,
+      ),
+    ).toBeInTheDocument();
+  });
+
+  it.each([
+    ['inactive', false, 50, '100'],
+    ['zero rate', true, 0, '100'],
+    ['insane rate', true, 10001, '100'],
+    ['zero gross', true, 50, '0'],
+  ])('renders nothing when %s', (_label, active, rateBps, gross) => {
+    const { container } = render(
+      <ExitFeeRow
+        gross={Decimal.from(gross)}
+        rateBps={rateBps as number}
+        active={active as boolean}
+        assetSymbol="DLLR"
+      />,
+    );
+    expect(container).toBeEmptyDOMElement();
+  });
+});

--- a/apps/frontend/src/app/2_molecules/ExitFeeRow/ExitFeeRow.tsx
+++ b/apps/frontend/src/app/2_molecules/ExitFeeRow/ExitFeeRow.tsx
@@ -1,0 +1,103 @@
+import React, { FC, useMemo } from 'react';
+
+import { t } from 'i18next';
+
+import { HelperButton, SimpleTableRow, TooltipTrigger } from '@sovryn/ui';
+import { Decimal } from '@sovryn/utils';
+
+import { TOKEN_RENDER_PRECISION } from '../../../constants/currencies';
+import { getTokenDisplayName } from '../../../constants/tokens';
+import { translations } from '../../../locales/i18n';
+import { getExitFeeAmount, isExitFeeShown } from '../../../utils/exitFee';
+import { AmountRenderer } from '../AmountRenderer/AmountRenderer';
+
+/** `rateBps / 100`, integer-safe (e.g. 50 -> "0.5", 100 -> "1"). */
+const formatRate = (rateBps: number): string => {
+  const value = rateBps / 100;
+  return Number.isInteger(value) ? value.toFixed(0) : String(value);
+};
+
+export type ExitFeeTooltipContentProps = {
+  fee: Decimal;
+  rateBps: number;
+  assetSymbol: string;
+  precision?: number;
+  /** Fixed-gross surfaces (e.g. surplus claim) display the exact fee. */
+  approx?: boolean;
+};
+
+export const ExitFeeTooltipContent: FC<ExitFeeTooltipContentProps> = ({
+  fee,
+  rateBps,
+  assetSymbol,
+  precision = TOKEN_RENDER_PRECISION,
+  approx = true,
+}) => (
+  <div className="flex flex-col gap-2">
+    <span>
+      {t(translations.exitFee.label, { rate: formatRate(rateBps) })}:{' '}
+      <AmountRenderer
+        value={fee}
+        suffix={getTokenDisplayName(assetSymbol)}
+        precision={precision}
+        prefix={approx ? '~ ' : undefined}
+        showRoundingPrefix={false}
+      />
+    </span>
+    <span>{t(translations.exitFee.tooltip)}</span>
+  </div>
+);
+
+export type ExitFeeRowProps = {
+  gross: Decimal;
+  rateBps: number;
+  active: boolean;
+  assetSymbol: string;
+  precision?: number;
+};
+
+export const ExitFeeRow: FC<ExitFeeRowProps> = ({
+  gross,
+  rateBps,
+  active,
+  assetSymbol,
+  precision = TOKEN_RENDER_PRECISION,
+}) => {
+  const fee = useMemo(() => getExitFeeAmount(gross, rateBps), [gross, rateBps]);
+
+  if (!isExitFeeShown(active, rateBps, fee)) {
+    return null;
+  }
+
+  return (
+    <SimpleTableRow
+      label={
+        <span className="flex flex-row items-center gap-1 whitespace-nowrap">
+          {t(translations.exitFee.youWillReceive)}
+          <HelperButton
+            content={
+              <ExitFeeTooltipContent
+                fee={fee}
+                rateBps={rateBps}
+                assetSymbol={assetSymbol}
+                precision={precision}
+              />
+            }
+            trigger={TooltipTrigger.click}
+            dataAttribute="exit-fee-helper"
+          />
+        </span>
+      }
+      value={
+        <AmountRenderer
+          value={gross.sub(fee)}
+          suffix={getTokenDisplayName(assetSymbol)}
+          precision={precision}
+          prefix="~ "
+          showRoundingPrefix={false}
+        />
+      }
+      dataAttribute="exit-fee-net"
+    />
+  );
+};

--- a/apps/frontend/src/app/2_molecules/ExitFeeRow/ExitFeeRow.tsx
+++ b/apps/frontend/src/app/2_molecules/ExitFeeRow/ExitFeeRow.tsx
@@ -8,7 +8,7 @@ import { Decimal } from '@sovryn/utils';
 import { TOKEN_RENDER_PRECISION } from '../../../constants/currencies';
 import { getTokenDisplayName } from '../../../constants/tokens';
 import { translations } from '../../../locales/i18n';
-import { getExitFeeAmount, isExitFeeShown } from '../../../utils/exitFee';
+import { getExitFeeAmount, getExitFeeDisplay } from '../../../utils/exitFee';
 import { AmountRenderer } from '../AmountRenderer/AmountRenderer';
 
 /** `rateBps / 100`, integer-safe (e.g. 50 -> "0.5", 100 -> "1"). */
@@ -54,6 +54,14 @@ export type ExitFeeRowProps = {
   active: boolean;
   assetSymbol: string;
   precision?: number;
+  /**
+   * Required on purpose. The perimeter fails open, so a quote we could not get
+   * and a quote of zero look identical in `active`/`rateBps`; making the caller
+   * state which one this is stops the row from silently promising "no fee"
+   * while the quote is still loading or the RPC is down.
+   */
+  unknown: boolean;
+  loading?: boolean;
 };
 
 export const ExitFeeRow: FC<ExitFeeRowProps> = ({
@@ -62,11 +70,33 @@ export const ExitFeeRow: FC<ExitFeeRowProps> = ({
   active,
   assetSymbol,
   precision = TOKEN_RENDER_PRECISION,
+  unknown,
+  loading = false,
 }) => {
   const fee = useMemo(() => getExitFeeAmount(gross, rateBps), [gross, rateBps]);
+  const display = getExitFeeDisplay({ active, rateBps, unknown, loading }, fee);
 
-  if (!isExitFeeShown(active, rateBps, fee)) {
+  if (display === 'none') {
     return null;
+  }
+
+  if (display === 'unknown') {
+    return (
+      <SimpleTableRow
+        label={
+          <span className="flex flex-row items-center gap-1 whitespace-nowrap">
+            {t(translations.exitFee.unavailable)}
+            <HelperButton
+              content={t(translations.exitFee.unavailableTooltip)}
+              trigger={TooltipTrigger.click}
+              dataAttribute="exit-fee-unavailable-helper"
+            />
+          </span>
+        }
+        value="—"
+        dataAttribute="exit-fee-unavailable"
+      />
+    );
   }
 
   return (

--- a/apps/frontend/src/app/2_molecules/ExitFeeRow/ExitFeeRow.tsx
+++ b/apps/frontend/src/app/2_molecules/ExitFeeRow/ExitFeeRow.tsx
@@ -55,10 +55,10 @@ export type ExitFeeRowProps = {
   assetSymbol: string;
   precision?: number;
   /**
-   * Required on purpose. The perimeter fails open, so a quote we could not get
-   * and a quote of zero look identical in `active`/`rateBps`; making the caller
-   * state which one this is stops the row from silently promising "no fee"
-   * while the quote is still loading or the RPC is down.
+   * Whether the quote was obtained at all. Either way the row is hidden when
+   * nothing is charged — the perimeter fails open, so an unobtainable quote
+   * means the chain pays the gross — but the hooks report the distinction and
+   * the caller is asked to pass it through rather than drop it.
    */
   unknown: boolean;
   loading?: boolean;
@@ -78,25 +78,6 @@ export const ExitFeeRow: FC<ExitFeeRowProps> = ({
 
   if (display === 'none') {
     return null;
-  }
-
-  if (display === 'unknown') {
-    return (
-      <SimpleTableRow
-        label={
-          <span className="flex flex-row items-center gap-1 whitespace-nowrap">
-            {t(translations.exitFee.unavailable)}
-            <HelperButton
-              content={t(translations.exitFee.unavailableTooltip)}
-              trigger={TooltipTrigger.click}
-              dataAttribute="exit-fee-unavailable-helper"
-            />
-          </span>
-        }
-        value="—"
-        dataAttribute="exit-fee-unavailable"
-      />
-    );
   }
 
   return (

--- a/apps/frontend/src/app/2_molecules/LOCStatus/LOCStatus.test.tsx
+++ b/apps/frontend/src/app/2_molecules/LOCStatus/LOCStatus.test.tsx
@@ -1,0 +1,98 @@
+import { render, screen, fireEvent } from '@testing-library/react';
+
+import React from 'react';
+
+import 'jest-canvas-mock';
+
+import { Decimal } from '@sovryn/utils';
+
+import { i18n } from '../../../locales/i18n';
+import { LOCStatus } from './LOCStatus';
+
+const mockRate = {
+  active: true,
+  rateBps: 50,
+  loading: false,
+};
+
+jest.mock('nanoid', () => {
+  return { nanoid: () => '1234' };
+});
+
+jest.mock('../../../contexts/NotificationContext', () => {
+  return {
+    useNotificationContext: () => ({
+      addNotification: jest.fn(),
+    }),
+  };
+});
+
+jest.mock('../../../hooks/exitFee/useExitFeeRate', () => ({
+  useExitFeeRate: () => mockRate,
+}));
+
+describe('LOCStatus perimeter fee', () => {
+  beforeAll(async () => {
+    await i18n;
+  });
+
+  beforeEach(() => {
+    Object.assign(mockRate, { active: true, rateBps: 50, loading: false });
+  });
+
+  it('shows the NET surplus with a fee tooltip when the fee is active', () => {
+    const { container } = render(
+      <LOCStatus
+        withdrawalSurplus={Decimal.from('0.4')}
+        collateral={Decimal.ZERO}
+        debt={Decimal.ZERO}
+        onWithdraw={jest.fn()}
+      />,
+    );
+
+    expect(screen.getByText(/0\.398/)).toBeInTheDocument();
+    expect(screen.queryByText(/^0\.4 /)).not.toBeInTheDocument();
+    // "Perimeter fee" only lives inside the (closed) tooltip, not inline.
+    expect(screen.queryByText(/^Perimeter fee/)).not.toBeInTheDocument();
+
+    const helperIcon = container.querySelector(
+      '[data-layout-id="exit-fee-helper"]',
+    );
+    expect(helperIcon).toBeInTheDocument();
+
+    fireEvent.click(helperIcon as Element);
+    expect(screen.getByText(/Perimeter fee \(0\.5%\)/)).toBeInTheDocument();
+  });
+
+  it('shows the gross surplus with no helper icon when the fee is inactive', () => {
+    Object.assign(mockRate, { active: false, rateBps: 0 });
+
+    const { container } = render(
+      <LOCStatus
+        withdrawalSurplus={Decimal.from('0.4')}
+        collateral={Decimal.ZERO}
+        debt={Decimal.ZERO}
+        onWithdraw={jest.fn()}
+      />,
+    );
+
+    expect(screen.getByText('0.4 BTC')).toBeInTheDocument();
+    expect(screen.queryByText(/Perimeter fee/)).not.toBeInTheDocument();
+    expect(
+      container.querySelector('[data-layout-id="exit-fee-helper"]'),
+    ).not.toBeInTheDocument();
+  });
+
+  it('does not render the surplus stat at all when there is no surplus', () => {
+    render(
+      <LOCStatus
+        withdrawalSurplus={Decimal.ZERO}
+        collateral={Decimal.ZERO}
+        debt={Decimal.ZERO}
+        onWithdraw={jest.fn()}
+      />,
+    );
+
+    expect(screen.queryByText('withdrawal surplus')).not.toBeInTheDocument();
+  });
+});

--- a/apps/frontend/src/app/2_molecules/LOCStatus/LOCStatus.tsx
+++ b/apps/frontend/src/app/2_molecules/LOCStatus/LOCStatus.tsx
@@ -139,6 +139,11 @@ export const LOCStatus: FC<LOCStatusProps> = ({
                   suffix={BITCOIN}
                   precision={BTC_RENDER_PRECISION}
                 />
+              ) : exitFeeUnavailable ? (
+                // Not a number: the surplus is charged a fee we could not read,
+                // so the gross is not what arrives and printing it would be a
+                // receipt we cannot honour.
+                '—'
               ) : (
                 `${withdrawalSurplus} ${BITCOIN}`
               )

--- a/apps/frontend/src/app/2_molecules/LOCStatus/LOCStatus.tsx
+++ b/apps/frontend/src/app/2_molecules/LOCStatus/LOCStatus.tsx
@@ -83,13 +83,6 @@ export const LOCStatus: FC<LOCStatusProps> = ({
     surplusExitFee,
   );
   const showSurplusExitFee = exitFeeDisplay === 'charged';
-  /**
-   * The surplus figure below is the gross when no fee is charged. That is the
-   * right number for a surface that is genuinely uncharged and the wrong one
-   * when we simply could not read the rate, so the unknown case says so
-   * instead of presenting the gross as settled.
-   */
-  const exitFeeUnavailable = exitFeeDisplay === 'unknown';
 
   return (
     <div
@@ -119,15 +112,6 @@ export const LOCStatus: FC<LOCStatusProps> = ({
                     dataAttribute="exit-fee-helper"
                   />
                 </span>
-              ) : exitFeeUnavailable ? (
-                <span className="flex flex-row items-center gap-1 whitespace-nowrap">
-                  {t('LOCStatus.withdrawalSurplus')}
-                  <HelperButton
-                    content={t('exitFee.unavailableTooltip')}
-                    trigger={TooltipTrigger.click}
-                    dataAttribute="exit-fee-unavailable-helper"
-                  />
-                </span>
               ) : (
                 t('LOCStatus.withdrawalSurplus')
               )
@@ -139,11 +123,6 @@ export const LOCStatus: FC<LOCStatusProps> = ({
                   suffix={BITCOIN}
                   precision={BTC_RENDER_PRECISION}
                 />
-              ) : exitFeeUnavailable ? (
-                // Not a number: the surplus is charged a fee we could not read,
-                // so the gross is not what arrives and printing it would be a
-                // receipt we cannot honour.
-                '—'
               ) : (
                 `${withdrawalSurplus} ${BITCOIN}`
               )

--- a/apps/frontend/src/app/2_molecules/LOCStatus/LOCStatus.tsx
+++ b/apps/frontend/src/app/2_molecules/LOCStatus/LOCStatus.tsx
@@ -25,7 +25,7 @@ import { COMMON_SYMBOLS } from '../../../utils/asset';
 import {
   SURFACE_ZERO_CLAIM_SURPLUS,
   getExitFeeAmount,
-  isExitFeeShown,
+  getExitFeeDisplay,
 } from '../../../utils/exitFee';
 import { AmountRenderer } from '../AmountRenderer/AmountRenderer';
 import { ExitFeeTooltipContent } from '../ExitFeeRow/ExitFeeRow';
@@ -60,7 +60,12 @@ export const LOCStatus: FC<LOCStatusProps> = ({
 
   const ratio = useMemo(() => parseInt(cRatio.toString()), [cRatio]);
 
-  const { active: exitFeeActive, rateBps: exitFeeRateBps } = useExitFeeRate(
+  const {
+    active: exitFeeActive,
+    rateBps: exitFeeRateBps,
+    unknown: exitFeeUnknown,
+    loading: exitFeeLoading,
+  } = useExitFeeRate(
     SURFACE_ZERO_CLAIM_SURPLUS,
     constants.AddressZero, // ethers constants — subProduct dimension unused for Zero
   );
@@ -68,11 +73,23 @@ export const LOCStatus: FC<LOCStatusProps> = ({
     () => getExitFeeAmount(withdrawalSurplus, exitFeeRateBps),
     [withdrawalSurplus, exitFeeRateBps],
   );
-  const showSurplusExitFee = isExitFeeShown(
-    exitFeeActive,
-    exitFeeRateBps,
+  const exitFeeDisplay = getExitFeeDisplay(
+    {
+      active: exitFeeActive,
+      rateBps: exitFeeRateBps,
+      unknown: exitFeeUnknown,
+      loading: exitFeeLoading,
+    },
     surplusExitFee,
   );
+  const showSurplusExitFee = exitFeeDisplay === 'charged';
+  /**
+   * The surplus figure below is the gross when no fee is charged. That is the
+   * right number for a surface that is genuinely uncharged and the wrong one
+   * when we simply could not read the rate, so the unknown case says so
+   * instead of presenting the gross as settled.
+   */
+  const exitFeeUnavailable = exitFeeDisplay === 'unknown';
 
   return (
     <div
@@ -100,6 +117,15 @@ export const LOCStatus: FC<LOCStatusProps> = ({
                     }
                     trigger={TooltipTrigger.click}
                     dataAttribute="exit-fee-helper"
+                  />
+                </span>
+              ) : exitFeeUnavailable ? (
+                <span className="flex flex-row items-center gap-1 whitespace-nowrap">
+                  {t('LOCStatus.withdrawalSurplus')}
+                  <HelperButton
+                    content={t('exitFee.unavailableTooltip')}
+                    trigger={TooltipTrigger.click}
+                    dataAttribute="exit-fee-unavailable-helper"
                   />
                 </span>
               ) : (

--- a/apps/frontend/src/app/2_molecules/LOCStatus/LOCStatus.tsx
+++ b/apps/frontend/src/app/2_molecules/LOCStatus/LOCStatus.tsx
@@ -122,6 +122,10 @@ export const LOCStatus: FC<LOCStatusProps> = ({
                   value={withdrawalSurplus.sub(surplusExitFee)}
                   suffix={BITCOIN}
                   precision={BTC_RENDER_PRECISION}
+                  // The surplus is a fixed gross, so this net is exact — no
+                  // "~", which AmountRenderer would otherwise add on its own
+                  // whenever the value carries more decimals than it shows.
+                  showRoundingPrefix={false}
                 />
               ) : (
                 `${withdrawalSurplus} ${BITCOIN}`

--- a/apps/frontend/src/app/2_molecules/LOCStatus/LOCStatus.tsx
+++ b/apps/frontend/src/app/2_molecules/LOCStatus/LOCStatus.tsx
@@ -1,10 +1,17 @@
 import React, { FC, useMemo } from 'react';
 
 import classNames from 'classnames';
+import { constants } from 'ethers';
 import { t } from 'i18next';
 import CountUp from 'react-countup';
 
-import { Button, ButtonSize, ButtonStyle } from '@sovryn/ui';
+import {
+  Button,
+  ButtonSize,
+  ButtonStyle,
+  HelperButton,
+  TooltipTrigger,
+} from '@sovryn/ui';
 import { Decimal } from '@sovryn/utils';
 
 import { RedemptionDialogButton } from '../../5_pages/ZeroPage/components/RedemptionDialog/RedemptionDialogButton';
@@ -13,7 +20,15 @@ import {
   BTC_RENDER_PRECISION,
   TOKEN_RENDER_PRECISION,
 } from '../../../constants/currencies';
+import { useExitFeeRate } from '../../../hooks/exitFee/useExitFeeRate';
+import { COMMON_SYMBOLS } from '../../../utils/asset';
+import {
+  SURFACE_ZERO_CLAIM_SURPLUS,
+  getExitFeeAmount,
+  isExitFeeShown,
+} from '../../../utils/exitFee';
 import { AmountRenderer } from '../AmountRenderer/AmountRenderer';
+import { ExitFeeTooltipContent } from '../ExitFeeRow/ExitFeeRow';
 import { CRatioIndicator } from './components/CRatioIndicator/CRatioIndicator';
 import { LOCStat } from './components/LOCStat/LOCStat';
 
@@ -45,6 +60,20 @@ export const LOCStatus: FC<LOCStatusProps> = ({
 
   const ratio = useMemo(() => parseInt(cRatio.toString()), [cRatio]);
 
+  const { active: exitFeeActive, rateBps: exitFeeRateBps } = useExitFeeRate(
+    SURFACE_ZERO_CLAIM_SURPLUS,
+    constants.AddressZero, // ethers constants — subProduct dimension unused for Zero
+  );
+  const surplusExitFee = useMemo(
+    () => getExitFeeAmount(withdrawalSurplus, exitFeeRateBps),
+    [withdrawalSurplus, exitFeeRateBps],
+  );
+  const showSurplusExitFee = isExitFeeShown(
+    exitFeeActive,
+    exitFeeRateBps,
+    surplusExitFee,
+  );
+
   return (
     <div
       className={classNames(
@@ -55,8 +84,39 @@ export const LOCStatus: FC<LOCStatusProps> = ({
       <div className="flex items-center flex-wrap gap-6">
         {hasWithdrawalSurplus && (
           <LOCStat
-            label={t('LOCStatus.withdrawalSurplus')}
-            value={`${withdrawalSurplus} ${BITCOIN}`}
+            label={
+              showSurplusExitFee ? (
+                <span className="flex flex-row items-center gap-1 whitespace-nowrap">
+                  {t('LOCStatus.withdrawalSurplus')}
+                  <HelperButton
+                    content={
+                      <ExitFeeTooltipContent
+                        fee={surplusExitFee}
+                        rateBps={exitFeeRateBps}
+                        assetSymbol={COMMON_SYMBOLS.BTC}
+                        precision={BTC_RENDER_PRECISION}
+                        approx={false}
+                      />
+                    }
+                    trigger={TooltipTrigger.click}
+                    dataAttribute="exit-fee-helper"
+                  />
+                </span>
+              ) : (
+                t('LOCStatus.withdrawalSurplus')
+              )
+            }
+            value={
+              showSurplusExitFee ? (
+                <AmountRenderer
+                  value={withdrawalSurplus.sub(surplusExitFee)}
+                  suffix={BITCOIN}
+                  precision={BTC_RENDER_PRECISION}
+                />
+              ) : (
+                `${withdrawalSurplus} ${BITCOIN}`
+              )
+            }
           />
         )}
         {showOpenLOC && (

--- a/apps/frontend/src/app/3_organisms/ZeroLocForm/CloseCreditLine.test.tsx
+++ b/apps/frontend/src/app/3_organisms/ZeroLocForm/CloseCreditLine.test.tsx
@@ -1,0 +1,96 @@
+import { render, screen, fireEvent } from '@testing-library/react';
+
+import React from 'react';
+
+import 'jest-canvas-mock';
+
+import { Decimal } from '@sovryn/utils';
+
+import { i18n } from '../../../locales/i18n';
+import { CloseCreditLine } from './CloseCreditLine';
+
+const mockQuote = {
+  active: true,
+  rateBps: 50,
+  feeAmount: Decimal.from('0.002'),
+  netAmount: Decimal.from('0.398'),
+  loading: false,
+};
+
+jest.mock('nanoid', () => {
+  return { nanoid: () => '1234' };
+});
+
+jest.mock('../../../contexts/NotificationContext', () => {
+  return {
+    useNotificationContext: () => ({
+      addNotification: jest.fn(),
+    }),
+  };
+});
+
+jest.mock('../../../hooks/exitFee/useZeroExitFee', () => ({
+  useZeroExitFee: () => mockQuote,
+}));
+
+jest.mock('./hooks/useZeroData', () => ({
+  useZeroData: () => ({ isRecoveryMode: false }),
+}));
+
+jest.mock('../../../hooks/useMaintenance', () => ({
+  useMaintenance: () => ({ checkMaintenance: () => false, States: {} }),
+}));
+
+jest.mock('../../../hooks/useAssetBalance', () => {
+  const { Decimal: ActualDecimal } = jest.requireActual('@sovryn/utils');
+  return {
+    useAssetBalance: () => ({ balance: ActualDecimal.from(10000) }),
+  };
+});
+
+describe('CloseCreditLine perimeter fee', () => {
+  beforeAll(async () => {
+    await i18n;
+  });
+
+  it('shows the NET collateral to receive with a fee tooltip', () => {
+    const { container } = render(
+      <CloseCreditLine
+        collateralValue={Decimal.from('0.4')}
+        creditValue={Decimal.from(3000)}
+        onSubmit={jest.fn()}
+        rbtcPrice={Decimal.from(67000)}
+      />,
+    );
+    expect(screen.getByText('Collateral to receive')).toBeInTheDocument();
+    expect(screen.getByText(/0\.398/)).toBeInTheDocument();
+    expect(screen.queryByText(/^0\.4 /)).not.toBeInTheDocument();
+
+    // "Perimeter fee" only lives inside the (closed) tooltip, not as a row label.
+    expect(screen.queryByText(/^Perimeter fee/)).not.toBeInTheDocument();
+    const helperIcon = container.querySelector(
+      '[data-layout-id="exit-fee-helper"]',
+    );
+    expect(helperIcon).toBeInTheDocument();
+
+    fireEvent.click(helperIcon as Element);
+    expect(screen.getByText(/Perimeter fee \(0\.5%\)/)).toBeInTheDocument();
+  });
+
+  it('shows the gross with no helper icon when the fee is inactive', () => {
+    Object.assign(mockQuote, { active: false, rateBps: 0 });
+    const { container } = render(
+      <CloseCreditLine
+        collateralValue={Decimal.from('0.4')}
+        creditValue={Decimal.from(3000)}
+        onSubmit={jest.fn()}
+        rbtcPrice={Decimal.from(67000)}
+      />,
+    );
+    expect(screen.queryByText(/Perimeter fee/)).not.toBeInTheDocument();
+    expect(screen.getByText(/0\.4/)).toBeInTheDocument();
+    expect(
+      container.querySelector('[data-layout-id="exit-fee-helper"]'),
+    ).not.toBeInTheDocument();
+  });
+});

--- a/apps/frontend/src/app/3_organisms/ZeroLocForm/CloseCreditLine.tsx
+++ b/apps/frontend/src/app/3_organisms/ZeroLocForm/CloseCreditLine.tsx
@@ -191,6 +191,10 @@ export const CloseCreditLine: FC<CloseCreditLineProps> = ({
                 prefix="~ "
                 showRoundingPrefix={false}
               />
+            ) : exitFeeUnavailable ? (
+              // See LOCStatus: an unreadable fee means the gross is not the
+              // amount received, so we decline to name one.
+              '—'
             ) : (
               collateralValueRenderer(collateralValue)
             )

--- a/apps/frontend/src/app/3_organisms/ZeroLocForm/CloseCreditLine.tsx
+++ b/apps/frontend/src/app/3_organisms/ZeroLocForm/CloseCreditLine.tsx
@@ -61,13 +61,6 @@ export const CloseCreditLine: FC<CloseCreditLineProps> = ({
     [exitFee],
   );
   const showExitFee = exitFeeDisplay === 'charged';
-  /**
-   * Closing the line returns collateral through a charged surface, so the
-   * amount below is only the gross when nothing is charged. When the quote
-   * could not be read it is not evidence of that, and saying nothing would
-   * present the gross as settled.
-   */
-  const exitFeeUnavailable = exitFeeDisplay === 'unknown';
 
   const collateralToReceive = useMemo(
     () => (showExitFee ? exitFee.netAmount : collateralValue),
@@ -176,8 +169,6 @@ export const CloseCreditLine: FC<CloseCreditLineProps> = ({
                 assetSymbol={COMMON_SYMBOLS.BTC}
                 precision={BTC_RENDER_PRECISION}
               />
-            ) : exitFeeUnavailable ? (
-              t(translations.exitFee.unavailableTooltip)
             ) : undefined
           }
           tooltipTrigger={TooltipTrigger.click}
@@ -191,10 +182,6 @@ export const CloseCreditLine: FC<CloseCreditLineProps> = ({
                 prefix="~ "
                 showRoundingPrefix={false}
               />
-            ) : exitFeeUnavailable ? (
-              // See LOCStatus: an unreadable fee means the gross is not the
-              // amount received, so we decline to name one.
-              '—'
             ) : (
               collateralValueRenderer(collateralValue)
             )

--- a/apps/frontend/src/app/3_organisms/ZeroLocForm/CloseCreditLine.tsx
+++ b/apps/frontend/src/app/3_organisms/ZeroLocForm/CloseCreditLine.tsx
@@ -14,19 +14,23 @@ import {
   ParagraphStyle,
   Select,
   SimpleTable,
+  TooltipTrigger,
 } from '@sovryn/ui';
 import { Decimal } from '@sovryn/utils';
 
 import { AmountRenderer } from '../../2_molecules/AmountRenderer/AmountRenderer';
 import { AssetRenderer } from '../../2_molecules/AssetRenderer/AssetRenderer';
+import { ExitFeeTooltipContent } from '../../2_molecules/ExitFeeRow/ExitFeeRow';
 import { BITCOIN, BTC_RENDER_PRECISION } from '../../../constants/currencies';
 import { getTokenDisplayName } from '../../../constants/tokens';
+import { useZeroExitFee } from '../../../hooks/exitFee/useZeroExitFee';
 import { useAssetBalance } from '../../../hooks/useAssetBalance';
 import { useMaintenance } from '../../../hooks/useMaintenance';
 import { translations } from '../../../locales/i18n';
+import { COMMON_SYMBOLS } from '../../../utils/asset';
+import { isExitFeeShown } from '../../../utils/exitFee';
 import { Row } from './Row';
 import { useZeroData } from './hooks/useZeroData';
-import { COMMON_SYMBOLS } from '../../../utils/asset';
 
 type CloseCreditLineProps = {
   collateralValue: Decimal;
@@ -49,6 +53,18 @@ export const CloseCreditLine: FC<CloseCreditLineProps> = ({
   const dllrLocked = checkMaintenance(States.ZERO_DLLR);
 
   const { balance: availableBalance } = useAssetBalance(creditToken);
+
+  const exitFee = useZeroExitFee(collateralValue);
+
+  const showExitFee = useMemo(
+    () => isExitFeeShown(exitFee.active, exitFee.rateBps, exitFee.feeAmount),
+    [exitFee],
+  );
+
+  const collateralToReceive = useMemo(
+    () => (showExitFee ? exitFee.netAmount : collateralValue),
+    [showExitFee, exitFee.netAmount, collateralValue],
+  );
 
   const collateralValueRenderer = useCallback(
     (value: Decimal) => (
@@ -144,7 +160,31 @@ export const CloseCreditLine: FC<CloseCreditLineProps> = ({
       >
         <Row
           label={t(translations.closeCreditLine.fields.collateral.label)}
-          value={collateralValueRenderer(collateralValue)}
+          tooltip={
+            showExitFee ? (
+              <ExitFeeTooltipContent
+                fee={exitFee.feeAmount}
+                rateBps={exitFee.rateBps}
+                assetSymbol={COMMON_SYMBOLS.BTC}
+                precision={BTC_RENDER_PRECISION}
+              />
+            ) : undefined
+          }
+          tooltipTrigger={TooltipTrigger.click}
+          tooltipDataAttribute="exit-fee-helper"
+          value={
+            showExitFee ? (
+              <AmountRenderer
+                value={collateralToReceive}
+                suffix={BITCOIN}
+                precision={BTC_RENDER_PRECISION}
+                prefix="~ "
+                showRoundingPrefix={false}
+              />
+            ) : (
+              collateralValueRenderer(collateralValue)
+            )
+          }
         />
       </SimpleTable>
 

--- a/apps/frontend/src/app/3_organisms/ZeroLocForm/CloseCreditLine.tsx
+++ b/apps/frontend/src/app/3_organisms/ZeroLocForm/CloseCreditLine.tsx
@@ -28,7 +28,7 @@ import { useAssetBalance } from '../../../hooks/useAssetBalance';
 import { useMaintenance } from '../../../hooks/useMaintenance';
 import { translations } from '../../../locales/i18n';
 import { COMMON_SYMBOLS } from '../../../utils/asset';
-import { isExitFeeShown } from '../../../utils/exitFee';
+import { getExitFeeDisplay } from '../../../utils/exitFee';
 import { Row } from './Row';
 import { useZeroData } from './hooks/useZeroData';
 
@@ -56,10 +56,18 @@ export const CloseCreditLine: FC<CloseCreditLineProps> = ({
 
   const exitFee = useZeroExitFee(collateralValue);
 
-  const showExitFee = useMemo(
-    () => isExitFeeShown(exitFee.active, exitFee.rateBps, exitFee.feeAmount),
+  const exitFeeDisplay = useMemo(
+    () => getExitFeeDisplay(exitFee, exitFee.feeAmount),
     [exitFee],
   );
+  const showExitFee = exitFeeDisplay === 'charged';
+  /**
+   * Closing the line returns collateral through a charged surface, so the
+   * amount below is only the gross when nothing is charged. When the quote
+   * could not be read it is not evidence of that, and saying nothing would
+   * present the gross as settled.
+   */
+  const exitFeeUnavailable = exitFeeDisplay === 'unknown';
 
   const collateralToReceive = useMemo(
     () => (showExitFee ? exitFee.netAmount : collateralValue),
@@ -168,6 +176,8 @@ export const CloseCreditLine: FC<CloseCreditLineProps> = ({
                 assetSymbol={COMMON_SYMBOLS.BTC}
                 precision={BTC_RENDER_PRECISION}
               />
+            ) : exitFeeUnavailable ? (
+              t(translations.exitFee.unavailableTooltip)
             ) : undefined
           }
           tooltipTrigger={TooltipTrigger.click}

--- a/apps/frontend/src/app/3_organisms/ZeroLocForm/Row.tsx
+++ b/apps/frontend/src/app/3_organisms/ZeroLocForm/Row.tsx
@@ -1,21 +1,35 @@
 import React, { FC, ReactNode } from 'react';
 
-import { HelperButton, SimpleTableRow } from '@sovryn/ui';
+import { HelperButton, SimpleTableRow, TooltipTrigger } from '@sovryn/ui';
 
 export type RowProps = {
   label: string;
-  tooltip?: string;
+  tooltip?: ReactNode;
+  tooltipTrigger?: TooltipTrigger;
+  tooltipDataAttribute?: string;
   value: ReactNode;
   valueClassName?: string;
 };
 
-export const Row: FC<RowProps> = ({ label, tooltip, ...props }) => (
+export const Row: FC<RowProps> = ({
+  label,
+  tooltip,
+  tooltipTrigger,
+  tooltipDataAttribute,
+  ...props
+}) => (
   <SimpleTableRow
     className="flex flex-row justify-between gap-4 items-center"
     label={
       <div className="flex flex-row gap-2 justify-start items-center whitespace-nowrap">
         {label}
-        {tooltip && <HelperButton content={tooltip} />}
+        {tooltip && (
+          <HelperButton
+            content={tooltip}
+            trigger={tooltipTrigger}
+            dataAttribute={tooltipDataAttribute}
+          />
+        )}
       </div>
     }
     {...props}

--- a/apps/frontend/src/app/3_organisms/ZeroLocForm/components/FormContent.test.tsx
+++ b/apps/frontend/src/app/3_organisms/ZeroLocForm/components/FormContent.test.tsx
@@ -1,0 +1,108 @@
+import { render, screen } from '@testing-library/react';
+
+import React from 'react';
+
+import 'jest-canvas-mock';
+
+import { Decimal } from '@sovryn/utils';
+
+import { i18n } from '../../../../locales/i18n';
+import { AmountType } from '../types';
+import { FormContent } from './FormContent';
+
+jest.mock('nanoid', () => {
+  return { nanoid: () => '1234' };
+});
+
+jest.mock('../../../../contexts/NotificationContext', () => {
+  return {
+    useNotificationContext: () => ({
+      addNotification: jest.fn(),
+    }),
+  };
+});
+
+// react-scripts' jest preset hoists jest.mock() calls above imports, so the
+// factory can't close over the top-level `Decimal` import directly — pull it
+// via requireActual instead (same pattern as LendingForm.test.tsx).
+jest.mock('../../../../hooks/exitFee/useZeroExitFee', () => {
+  const { Decimal: ActualDecimal } = jest.requireActual('@sovryn/utils');
+  return {
+    useZeroExitFee: () => ({
+      active: true,
+      rateBps: 50,
+      feeAmount: ActualDecimal.ZERO,
+      netAmount: ActualDecimal.ZERO,
+      loading: false,
+    }),
+  };
+});
+
+jest.mock('../../../../hooks/useMaintenance', () => ({
+  useMaintenance: () => ({
+    checkMaintenance: () => false,
+    States: {},
+  }),
+}));
+
+jest.mock('../../../5_pages/ZeroPage/hooks/useLiquityBaseParams', () => {
+  const { Decimal: ActualDecimal } = jest.requireActual('@sovryn/utils');
+  return {
+    useLiquityBaseParams: () => ({
+      minBorrowingFeeRate: ActualDecimal.ZERO,
+      maxBorrowingFeeRate: ActualDecimal.from(0.05),
+    }),
+  };
+});
+
+const makeProps = (overrides: object = {}) =>
+  ({
+    hasTrove: true,
+    existingDebt: Decimal.from(3000),
+    existingCollateral: Decimal.from(0.4),
+    debtType: AmountType.Add,
+    onDebtTypeChange: jest.fn(),
+    collateralType: AmountType.Remove,
+    onCollateralTypeChange: jest.fn(),
+    rbtcPrice: Decimal.from(67000),
+    borrowingRate: Decimal.ZERO,
+    originationFee: Decimal.ZERO,
+    maxOriginationFeeRate: '5',
+    onMaxOriginationFeeRateChange: jest.fn(),
+    debtAmount: '0',
+    maxDebtAmount: Decimal.from(1000),
+    onDebtAmountChange: jest.fn(),
+    debtToken: 'zusd',
+    onDebtTokenChange: jest.fn(),
+    collateralAmount: '0.02',
+    maxCollateralAmount: Decimal.from(0.2),
+    onCollateralAmountChange: jest.fn(),
+    initialRatio: Decimal.from(200),
+    currentRatio: Decimal.from(180),
+    initialLiquidationPrice: Decimal.from(40000),
+    liquidationPrice: Decimal.from(45000),
+    initialLiquidationPriceInRecoveryMode: Decimal.from(50000),
+    liquidationPriceInRecoveryMode: Decimal.from(55000),
+    totalDebt: Decimal.from(3000),
+    totalCollateral: Decimal.from(0.38),
+    onFormSubmit: jest.fn(),
+    ...overrides,
+  } as any);
+
+describe('FormContent perimeter fee', () => {
+  beforeAll(async () => {
+    await i18n;
+  });
+
+  it('shows the "You will receive" row when withdrawing collateral', () => {
+    render(<FormContent {...makeProps()} />);
+    expect(screen.getByText('You will receive')).toBeInTheDocument();
+    // "Perimeter fee" only lives inside the (closed) tooltip, not as a row label.
+    expect(screen.queryByText(/^Perimeter fee/)).not.toBeInTheDocument();
+  });
+
+  it('hides the "You will receive" row when adding collateral', () => {
+    render(<FormContent {...makeProps({ collateralType: AmountType.Add })} />);
+    expect(screen.queryByText('You will receive')).not.toBeInTheDocument();
+  });
+});

--- a/apps/frontend/src/app/3_organisms/ZeroLocForm/components/FormContent.tsx
+++ b/apps/frontend/src/app/3_organisms/ZeroLocForm/components/FormContent.tsx
@@ -25,6 +25,7 @@ import { Decimal } from '@sovryn/utils';
 import { AdvancedSettings } from '../../../2_molecules/AdvancedSettings/AdvancedSettings';
 import { AmountRenderer } from '../../../2_molecules/AmountRenderer/AmountRenderer';
 import { AssetRenderer } from '../../../2_molecules/AssetRenderer/AssetRenderer';
+import { ExitFeeRow } from '../../../2_molecules/ExitFeeRow/ExitFeeRow';
 import { BORROW_ASSETS } from '../../../5_pages/ZeroPage/constants';
 import { useLiquityBaseParams } from '../../../5_pages/ZeroPage/hooks/useLiquityBaseParams';
 import {
@@ -35,14 +36,15 @@ import {
 } from '../../../../constants/currencies';
 import { COLLATERAL_RATIO_THRESHOLDS } from '../../../../constants/general';
 import { WIKI_LINKS } from '../../../../constants/links';
+import { useZeroExitFee } from '../../../../hooks/exitFee/useZeroExitFee';
 import { useMaintenance } from '../../../../hooks/useMaintenance';
 import { translations } from '../../../../locales/i18n';
+import { COMMON_SYMBOLS } from '../../../../utils/asset';
 import { formatValue, decimalic } from '../../../../utils/math';
 import { CurrentTroveData } from '../CurrentTroveData';
 import { Label } from '../Label';
 import { Row } from '../Row';
 import { AmountType } from '../types';
-import { COMMON_SYMBOLS } from '../../../../utils/asset';
 
 export type OpenTroveProps = {
   hasTrove: false;
@@ -148,6 +150,16 @@ export const FormContent: FC<FormContentProps> = props => {
   const isBorrowDisabled = useMemo(
     () => borrowLocked && props.hasTrove && props.debtType === AmountType.Add,
     [borrowLocked, props],
+  );
+
+  const { active: exitFeeActive, rateBps: exitFeeRateBps } = useZeroExitFee();
+
+  const exitFeeGross = useMemo(
+    () =>
+      props.hasTrove && props.collateralType === AmountType.Remove
+        ? decimalic(props.collateralAmount)
+        : Decimal.ZERO,
+    [props],
   );
 
   const { minBorrowingFeeRate, maxBorrowingFeeRate } = useLiquityBaseParams();
@@ -488,6 +500,13 @@ export const FormContent: FC<FormContentProps> = props => {
                     renderer={renderTotalCollateral}
                   />
                 }
+              />
+              <ExitFeeRow
+                gross={exitFeeGross}
+                rateBps={exitFeeRateBps}
+                active={exitFeeActive}
+                assetSymbol={COMMON_SYMBOLS.BTC}
+                precision={BTC_RENDER_PRECISION}
               />
             </>
           ) : (

--- a/apps/frontend/src/app/3_organisms/ZeroLocForm/components/FormContent.tsx
+++ b/apps/frontend/src/app/3_organisms/ZeroLocForm/components/FormContent.tsx
@@ -152,7 +152,12 @@ export const FormContent: FC<FormContentProps> = props => {
     [borrowLocked, props],
   );
 
-  const { active: exitFeeActive, rateBps: exitFeeRateBps } = useZeroExitFee();
+  const {
+    active: exitFeeActive,
+    rateBps: exitFeeRateBps,
+    unknown: exitFeeUnknown,
+    loading: exitFeeLoading,
+  } = useZeroExitFee();
 
   const exitFeeGross = useMemo(
     () =>
@@ -502,6 +507,8 @@ export const FormContent: FC<FormContentProps> = props => {
                 }
               />
               <ExitFeeRow
+                unknown={exitFeeUnknown}
+                loading={exitFeeLoading}
                 gross={exitFeeGross}
                 rateBps={exitFeeRateBps}
                 active={exitFeeActive}

--- a/apps/frontend/src/app/5_pages/BorrowPage/BorrowPage.utils.test.tsx
+++ b/apps/frontend/src/app/5_pages/BorrowPage/BorrowPage.utils.test.tsx
@@ -1,0 +1,87 @@
+import 'jest-canvas-mock';
+
+import { Decimal } from '@sovryn/utils';
+
+import { getBorrowerExitFeeGross } from './BorrowPage.utils';
+
+jest.mock('nanoid', () => {
+  return { nanoid: () => '1234' };
+});
+
+const base = {
+  isCloseTab: false,
+  isRepayTab: false,
+  isCollateralWithdrawTab: false,
+  loanCollateral: Decimal.from(10),
+  collateralSize: Decimal.from(2),
+  collateralWithdrawn: Decimal.from(3),
+  debtSize: Decimal.from(500),
+  maximumRepayAmount: Decimal.from(1000),
+};
+
+describe('getBorrowerExitFeeGross', () => {
+  it('close tab returns the full collateral', () => {
+    expect(
+      getBorrowerExitFeeGross({ ...base, isCloseTab: true }).toString(),
+    ).toEqual('10');
+  });
+
+  it('repay tab returns the proportional withdrawal', () => {
+    expect(
+      getBorrowerExitFeeGross({ ...base, isRepayTab: true }).toString(),
+    ).toEqual('3');
+  });
+
+  it('full repay returns the full collateral', () => {
+    expect(
+      getBorrowerExitFeeGross({
+        ...base,
+        isRepayTab: true,
+        debtSize: Decimal.from(1000),
+      }).toString(),
+    ).toEqual('10');
+  });
+
+  it('repay tab with zero debt input returns zero', () => {
+    expect(
+      getBorrowerExitFeeGross({
+        ...base,
+        isRepayTab: true,
+        debtSize: Decimal.ZERO,
+      }).isZero(),
+    ).toBe(true);
+  });
+
+  it('withdraw-collateral tab returns the entered amount', () => {
+    expect(
+      getBorrowerExitFeeGross({
+        ...base,
+        isCollateralWithdrawTab: true,
+      }).toString(),
+    ).toEqual('2');
+  });
+
+  it('borrow/add tabs return zero', () => {
+    expect(getBorrowerExitFeeGross(base).isZero()).toBe(true);
+  });
+
+  it('close tab wins over simultaneous collateral-withdraw tab', () => {
+    expect(
+      getBorrowerExitFeeGross({
+        ...base,
+        isCloseTab: true,
+        isCollateralWithdrawTab: true,
+      }).toString(),
+    ).toEqual('10');
+  });
+
+  it('repay tab wins over simultaneous collateral-withdraw tab', () => {
+    expect(
+      getBorrowerExitFeeGross({
+        ...base,
+        isRepayTab: true,
+        isCollateralWithdrawTab: true,
+      }).toString(),
+    ).toEqual('3');
+  });
+});

--- a/apps/frontend/src/app/5_pages/BorrowPage/BorrowPage.utils.tsx
+++ b/apps/frontend/src/app/5_pages/BorrowPage/BorrowPage.utils.tsx
@@ -20,7 +20,11 @@ import {
 } from '../../../constants/lending';
 import { translations } from '../../../locales/i18n';
 import { COMMON_SYMBOLS, findAsset } from '../../../utils/asset';
-import { isBitpro, isBtcBasedAsset } from '../../../utils/helpers';
+import {
+  areValuesIdentical,
+  isBitpro,
+  isBtcBasedAsset,
+} from '../../../utils/helpers';
 import { decimalic } from '../../../utils/math';
 
 export const renderValue = (
@@ -114,4 +118,43 @@ export const normalizeTokenWrapped = (token: string): string => {
   }
 
   return normalizeToken(token);
+};
+
+export const getBorrowerExitFeeGross = ({
+  isCloseTab,
+  isRepayTab,
+  isCollateralWithdrawTab,
+  loanCollateral,
+  collateralSize,
+  collateralWithdrawn,
+  debtSize,
+  maximumRepayAmount,
+}: {
+  isCloseTab: boolean;
+  isRepayTab: boolean;
+  isCollateralWithdrawTab: boolean;
+  loanCollateral: Decimal;
+  collateralSize: Decimal;
+  collateralWithdrawn: Decimal;
+  debtSize: Decimal;
+  maximumRepayAmount: Decimal;
+}): Decimal => {
+  // Order matters: Repay/Close force the collateral tab to Withdraw
+  // (AdjustLoanForm.onDebtTabChange), so close/repay must win over
+  // isCollateralWithdrawTab.
+  if (isCloseTab) {
+    return loanCollateral;
+  }
+  if (isRepayTab) {
+    if (debtSize.isZero()) {
+      return Decimal.ZERO;
+    }
+    return areValuesIdentical(debtSize, maximumRepayAmount)
+      ? loanCollateral
+      : collateralWithdrawn;
+  }
+  if (isCollateralWithdrawTab) {
+    return collateralSize;
+  }
+  return Decimal.ZERO;
 };

--- a/apps/frontend/src/app/5_pages/BorrowPage/components/AdjustLoanForm/AdjustLoanForm.tsx
+++ b/apps/frontend/src/app/5_pages/BorrowPage/components/AdjustLoanForm/AdjustLoanForm.tsx
@@ -17,26 +17,34 @@ import {
 } from '@sovryn/ui';
 import { Decimal } from '@sovryn/utils';
 
+import { RSK_CHAIN_ID } from '../../../../../config/chains';
+
 import { AmountRenderer } from '../../../../2_molecules/AmountRenderer/AmountRenderer';
 import { AssetRenderer } from '../../../../2_molecules/AssetRenderer/AssetRenderer';
+import { ExitFeeRow } from '../../../../2_molecules/ExitFeeRow/ExitFeeRow';
 import { LabelWithTabsAndMaxButton } from '../../../../2_molecules/LabelWithTabsAndMaxButton/LabelWithTabsAndMaxButton';
 import { convertLoanTokenToSupportedAssets } from '../../../../5_pages/BorrowPage/components/OpenLoansTable/OpenLoans.utils';
 import { LoanItem } from '../../../../5_pages/BorrowPage/components/OpenLoansTable/OpenLoansTable.types';
 import { useGetMinCollateralRatio } from '../../../../5_pages/BorrowPage/hooks/useGetMinCollateralRatio';
+import { BTC_RENDER_PRECISION } from '../../../../../constants/currencies';
 import {
   MINIMUM_COLLATERAL_RATIO_LENDING_POOLS,
   MINIMUM_COLLATERAL_RATIO_LENDING_POOLS_SOV,
 } from '../../../../../constants/lending';
 import { getTokenDisplayName } from '../../../../../constants/tokens';
+import { useExitFeeRate } from '../../../../../hooks/exitFee/useExitFeeRate';
 import { useDecimalAmountInput } from '../../../../../hooks/useDecimalAmountInput';
+import { useLoadContract } from '../../../../../hooks/useLoadContract';
 import { useMaxAssetBalance } from '../../../../../hooks/useMaxAssetBalance';
 import { useQueryRate } from '../../../../../hooks/useQueryRate';
 import { translations } from '../../../../../locales/i18n';
 import { COMMON_SYMBOLS } from '../../../../../utils/asset';
+import { SURFACE_LENDING_BORROWER_WITHDRAW } from '../../../../../utils/exitFee';
 import { areValuesIdentical } from '../../../../../utils/helpers';
 import { decimalic } from '../../../../../utils/math';
 import {
   calculatePrepaidInterestFromDuration,
+  getBorrowerExitFeeGross,
   getCollateralRatioThresholds,
   getOriginationFeeAmount,
   normalizeToken,
@@ -255,6 +263,41 @@ export const AdjustLoanForm: FC<AdjustLoanFormProps> = ({ loan }) => {
     maximumRepayAmount,
     collateralWithdrawn,
   ]);
+
+  const loanTokenContract = useLoadContract(
+    debtToken,
+    'loanTokens',
+    RSK_CHAIN_ID,
+  );
+
+  const { active: exitFeeActive, rateBps: exitFeeRateBps } = useExitFeeRate(
+    SURFACE_LENDING_BORROWER_WITHDRAW,
+    loanTokenContract?.address,
+  );
+
+  const exitFeeGross = useMemo(
+    () =>
+      getBorrowerExitFeeGross({
+        isCloseTab,
+        isRepayTab,
+        isCollateralWithdrawTab,
+        loanCollateral: decimalic(loan.collateral.toString()),
+        collateralSize,
+        collateralWithdrawn,
+        debtSize,
+        maximumRepayAmount,
+      }),
+    [
+      isCloseTab,
+      isRepayTab,
+      isCollateralWithdrawTab,
+      loan.collateral,
+      collateralSize,
+      collateralWithdrawn,
+      debtSize,
+      maximumRepayAmount,
+    ],
+  );
 
   const prepaidInterest = calculatePrepaidInterestFromDuration(
     borrowApr,
@@ -838,6 +881,13 @@ export const AdjustLoanForm: FC<AdjustLoanFormProps> = ({ loan }) => {
               }
             />
           )}
+          <ExitFeeRow
+            gross={exitFeeGross}
+            rateBps={exitFeeRateBps}
+            active={exitFeeActive}
+            assetSymbol={collateralToken}
+            precision={BTC_RENDER_PRECISION}
+          />
           {(isBorrowTab || isRepayTab) && (
             <SimpleTableRow
               label={t(pageTranslations.labels.newTotalDebt)}

--- a/apps/frontend/src/app/5_pages/BorrowPage/components/AdjustLoanForm/AdjustLoanForm.tsx
+++ b/apps/frontend/src/app/5_pages/BorrowPage/components/AdjustLoanForm/AdjustLoanForm.tsx
@@ -270,7 +270,12 @@ export const AdjustLoanForm: FC<AdjustLoanFormProps> = ({ loan }) => {
     RSK_CHAIN_ID,
   );
 
-  const { active: exitFeeActive, rateBps: exitFeeRateBps } = useExitFeeRate(
+  const {
+    active: exitFeeActive,
+    rateBps: exitFeeRateBps,
+    unknown: exitFeeUnknown,
+    loading: exitFeeLoading,
+  } = useExitFeeRate(
     SURFACE_LENDING_BORROWER_WITHDRAW,
     loanTokenContract?.address,
   );
@@ -882,6 +887,8 @@ export const AdjustLoanForm: FC<AdjustLoanFormProps> = ({ loan }) => {
             />
           )}
           <ExitFeeRow
+            unknown={exitFeeUnknown}
+            loading={exitFeeLoading}
             gross={exitFeeGross}
             rateBps={exitFeeRateBps}
             active={exitFeeActive}

--- a/apps/frontend/src/app/5_pages/LendPage/components/AdjustModal/LendingForm.test.tsx
+++ b/apps/frontend/src/app/5_pages/LendPage/components/AdjustModal/LendingForm.test.tsx
@@ -1,0 +1,85 @@
+import { render, screen, fireEvent } from '@testing-library/react';
+
+import React from 'react';
+
+import { BigNumber } from 'ethers';
+import 'jest-canvas-mock';
+
+import { Decimal } from '@sovryn/utils';
+
+import { i18n } from '../../../../../locales/i18n';
+import { asyncCall } from '../../../../../store/rxjs/provider-cache';
+import { LendingForm } from './LendingForm';
+
+jest.mock('nanoid', () => {
+  return { nanoid: () => '1234' };
+});
+
+jest.mock('../../../../../contexts/NotificationContext', () => {
+  return {
+    useNotificationContext: () => ({
+      addNotification: jest.fn(),
+    }),
+  };
+});
+
+jest.mock('../../../../../hooks/exitFee/useExitFeeRate', () => ({
+  useExitFeeRate: () => ({ active: true, rateBps: 50, loading: false }),
+}));
+
+jest.mock('../../../../../hooks/useMaxAssetBalance', () => {
+  const { Decimal: ActualDecimal } = jest.requireActual('@sovryn/utils');
+  return {
+    useMaxAssetBalance: () => ({ balance: ActualDecimal.from(1000) }),
+  };
+});
+
+// note: react-scripts' jest preset sets `resetMocks: true`, which strips any
+// mockResolvedValue configured inline here before every test runs — so
+// `asyncCall` is reconfigured fresh in `beforeEach` below instead.
+jest.mock('../../../../../store/rxjs/provider-cache', () => ({
+  ...jest.requireActual('../../../../../store/rxjs/provider-cache'),
+  asyncCall: jest.fn(),
+}));
+
+const state = {
+  token: 'dllr',
+  tokenDetails: { symbol: 'dllr' },
+  poolTokenContract: { address: '0x0000000000000000000000000000000000000001' },
+  balance: Decimal.from(5000),
+  liquidity: Decimal.from(100000),
+  apr: Decimal.from(2),
+} as any;
+
+describe('LendingForm perimeter fee', () => {
+  beforeAll(async () => {
+    await i18n;
+  });
+
+  beforeEach(() => {
+    (asyncCall as jest.Mock).mockResolvedValue(BigNumber.from(0));
+  });
+
+  it('shows the "You will receive" row on the withdraw tab once an amount is entered', () => {
+    render(<LendingForm state={state} onConfirm={jest.fn()} />);
+    fireEvent.click(screen.getByText('Withdraw'));
+    const input = screen.getByPlaceholderText('0');
+    fireEvent.change(input, { target: { value: '100' } });
+    // AmountInput/InputBase debounces onChangeText (default 500ms) for the
+    // "change" event; blur commits the value synchronously (type="number"
+    // path in InputBase.handleOnBlur), which is what the parent's `amount`
+    // state (and therefore ExitFeeRow) reacts to.
+    fireEvent.blur(input);
+    expect(screen.getByText('You will receive')).toBeInTheDocument();
+    // "Perimeter fee" only lives inside the (closed) tooltip, not as a row label.
+    expect(screen.queryByText(/^Perimeter fee/)).not.toBeInTheDocument();
+  });
+
+  it('shows no "You will receive" row on the deposit tab', () => {
+    render(<LendingForm state={state} onConfirm={jest.fn()} />);
+    const input = screen.getByPlaceholderText('0');
+    fireEvent.change(input, { target: { value: '100' } });
+    fireEvent.blur(input);
+    expect(screen.queryByText('You will receive')).not.toBeInTheDocument();
+  });
+});

--- a/apps/frontend/src/app/5_pages/LendPage/components/AdjustModal/LendingForm.tsx
+++ b/apps/frontend/src/app/5_pages/LendPage/components/AdjustModal/LendingForm.tsx
@@ -18,12 +18,15 @@ import { RSK_CHAIN_ID } from '../../../../../config/chains';
 
 import { AmountRenderer } from '../../../../2_molecules/AmountRenderer/AmountRenderer';
 import { AssetRenderer } from '../../../../2_molecules/AssetRenderer/AssetRenderer';
+import { ExitFeeRow } from '../../../../2_molecules/ExitFeeRow/ExitFeeRow';
 import { GAS_LIMIT } from '../../../../../constants/gasLimits';
 import { getTokenDisplayName } from '../../../../../constants/tokens';
+import { useExitFeeRate } from '../../../../../hooks/exitFee/useExitFeeRate';
 import { useMaxAssetBalance } from '../../../../../hooks/useMaxAssetBalance';
 import { useWeiAmountInput } from '../../../../../hooks/useWeiAmountInput';
 import { translations } from '../../../../../locales/i18n';
 import { asyncCall } from '../../../../../store/rxjs/provider-cache';
+import { SURFACE_LENDING_LENDER_WITHDRAW } from '../../../../../utils/exitFee';
 import { FullAdjustModalState } from './AdjustLendingModalContainer';
 import { Label } from './Label';
 
@@ -47,6 +50,16 @@ export const LendingForm: FC<DepositProps> = ({ state, onConfirm }) => {
     state.token,
     RSK_CHAIN_ID,
     GAS_LIMIT.LENDING_MINT,
+  );
+
+  const { active: exitFeeActive, rateBps: exitFeeRateBps } = useExitFeeRate(
+    SURFACE_LENDING_LENDER_WITHDRAW,
+    state.poolTokenContract.address,
+  );
+
+  const withdrawAmount = useMemo(
+    () => Decimal.fromBigNumberString(amount.toString()),
+    [amount],
   );
 
   const balance = useMemo(
@@ -181,6 +194,14 @@ export const LendingForm: FC<DepositProps> = ({ state, onConfirm }) => {
             />
           }
         />
+        {!isDeposit && (
+          <ExitFeeRow
+            gross={withdrawAmount}
+            rateBps={exitFeeRateBps}
+            active={exitFeeActive}
+            assetSymbol={state.tokenDetails.symbol}
+          />
+        )}
       </SimpleTable>
 
       <Button

--- a/apps/frontend/src/app/5_pages/LendPage/components/AdjustModal/LendingForm.tsx
+++ b/apps/frontend/src/app/5_pages/LendPage/components/AdjustModal/LendingForm.tsx
@@ -52,7 +52,12 @@ export const LendingForm: FC<DepositProps> = ({ state, onConfirm }) => {
     GAS_LIMIT.LENDING_MINT,
   );
 
-  const { active: exitFeeActive, rateBps: exitFeeRateBps } = useExitFeeRate(
+  const {
+    active: exitFeeActive,
+    rateBps: exitFeeRateBps,
+    unknown: exitFeeUnknown,
+    loading: exitFeeLoading,
+  } = useExitFeeRate(
     SURFACE_LENDING_LENDER_WITHDRAW,
     state.poolTokenContract.address,
   );
@@ -196,6 +201,8 @@ export const LendingForm: FC<DepositProps> = ({ state, onConfirm }) => {
         />
         {!isDeposit && (
           <ExitFeeRow
+            unknown={exitFeeUnknown}
+            loading={exitFeeLoading}
             gross={withdrawAmount}
             rateBps={exitFeeRateBps}
             active={exitFeeActive}

--- a/apps/frontend/src/hooks/exitFee/useExitFeeRate.ts
+++ b/apps/frontend/src/hooks/exitFee/useExitFeeRate.ts
@@ -1,0 +1,85 @@
+import { useMemo } from 'react';
+
+import { Contract, constants } from 'ethers';
+
+import { getProvider } from '@sovryn/ethers-provider';
+
+import { RSK_CHAIN_ID } from '../../config/chains';
+
+import { asyncCall } from '../../store/rxjs/provider-cache';
+import { EXIT_FEE_REFERENCE_GROSS, EXIT_FEE_TTL } from '../../utils/exitFee';
+import { useAccount } from '../useAccount';
+import { useCacheCall } from '../useCacheCall';
+import { useGetProtocolContract } from '../useGetContract';
+
+export type ExitFeeRate = {
+  active: boolean;
+  rateBps: number;
+  loading: boolean;
+};
+
+const INACTIVE = { active: false, rateBps: 0 };
+
+const CONTROLLER_GETTER_ABI = [
+  'function exitFeeController() view returns (address)',
+];
+
+const CONTROLLER_ABI = [
+  'function quoteExitFee(bytes32 surfaceId, address subProduct, address actor, uint256 grossAmount) view returns (tuple(bool active, uint16 rateBps, uint256 feeAmount, uint256 netAmount, address feeReceiver, uint8 reason))',
+];
+
+export const useExitFeeRate = (
+  surfaceId: string,
+  subProduct: string | undefined,
+): ExitFeeRate => {
+  const { account } = useAccount();
+  const protocol = useGetProtocolContract('protocol', RSK_CHAIN_ID);
+
+  const { value, loading } = useCacheCall(
+    `exitFee/rate/${surfaceId}/${subProduct}/${account}`,
+    RSK_CHAIN_ID,
+    async () => {
+      if (!protocol || !subProduct || !account) {
+        return INACTIVE;
+      }
+      try {
+        const getter = new Contract(
+          protocol.address,
+          CONTROLLER_GETTER_ABI,
+          getProvider(RSK_CHAIN_ID),
+        );
+        // negative-cached too: while undeployed this reverts and we cache INACTIVE
+        const controllerAddress: string = await asyncCall(
+          `exitFee/controllerAddress/${RSK_CHAIN_ID}/${protocol.address}`,
+          () => getter.exitFeeController(),
+          { ttl: EXIT_FEE_TTL },
+        );
+        if (!controllerAddress || controllerAddress === constants.AddressZero) {
+          return INACTIVE;
+        }
+        const controller = new Contract(
+          controllerAddress,
+          CONTROLLER_ABI,
+          getProvider(RSK_CHAIN_ID),
+        );
+        const [quote] = await controller.functions.quoteExitFee(
+          surfaceId,
+          subProduct,
+          account,
+          EXIT_FEE_REFERENCE_GROSS,
+        );
+        return { active: quote.active, rateBps: Number(quote.rateBps) };
+      } catch (error) {
+        return INACTIVE;
+      }
+    },
+    [protocol?.address, surfaceId, subProduct, account],
+    INACTIVE,
+    { ttl: EXIT_FEE_TTL },
+  );
+
+  return useMemo(
+    () => ({ active: value.active, rateBps: value.rateBps, loading }),
+    [value, loading],
+  );
+};

--- a/apps/frontend/src/hooks/exitFee/useExitFeeRate.ts
+++ b/apps/frontend/src/hooks/exitFee/useExitFeeRate.ts
@@ -18,8 +18,26 @@ import { useGetProtocolContract } from '../useGetContract';
 
 export type ExitFeeRate = ExitFeeQuote;
 
-/** No quote obtained. Renders as "unavailable", never as "no fee". */
+/**
+ * No quote obtained. The rows are hidden for this exactly as for a settled
+ * "no fee" — the chain fails open, so nothing is charged either way — but the
+ * hooks keep the distinction visible to their consumers.
+ */
 const UNKNOWN = { active: false, rateBps: 0, unknown: true };
+
+/**
+ * Stamp a fetched quote with the cache key it was fetched FOR.
+ *
+ * The shared cache keeps its previous state until the effect for a changed
+ * key has run and its result has landed, so on the first render after an
+ * account or pool switch `value` still belongs to the old key. A quote is
+ * only displayed when its stamp matches the key being asked about; until
+ * then the hook reports the hidden default.
+ */
+const stamped = async <T extends object>(
+  forKey: string,
+  fetch: () => Promise<T>,
+) => ({ ...(await fetch()), forKey });
 /**
  * A real answer of "nothing is charged": the protocol holds no controller
  * pointer, so the on-chain path charges nothing by construction. This is a
@@ -42,92 +60,98 @@ export const useExitFeeRate = (
   const { account } = useAccount();
   const protocol = useGetProtocolContract('protocol', RSK_CHAIN_ID);
 
+  const key = `exitFee/rate/${surfaceId}/${subProduct}/${account}`;
+
   const { value, loading } = useCacheCall(
-    `exitFee/rate/${surfaceId}/${subProduct}/${account}`,
+    key,
     RSK_CHAIN_ID,
-    async () => {
-      if (!protocol || !subProduct || !account) {
-        // Nothing to quote against yet. The spec's rule for every such case is
-        // that the form looks exactly as it does without the perimeter.
-        return UNCHARGED;
-      }
+    () =>
+      stamped(key, async () => {
+        if (!protocol || !subProduct || !account) {
+          // Nothing to quote against yet. The spec's rule for every such case is
+          // that the form looks exactly as it does without the perimeter.
+          return UNCHARGED;
+        }
 
-      const getter = new Contract(
-        protocol.address,
-        CONTROLLER_GETTER_ABI,
-        getProvider(RSK_CHAIN_ID),
-      );
-
-      let controllerAddress;
-      try {
-        // Negative-cached too: while undeployed this reverts and we cache the
-        // uncharged answer.
-        //
-        // Known and accepted: the pointer is cached for EXIT_FEE_TTL under a
-        // key with no block dimension, so at the moment governance pins the
-        // controller the app can report "no fee" for up to that long while the
-        // chain has started charging. The window is bounded, it exists once,
-        // and the release order already covers it -- the dapp ships before
-        // charging is enabled, never after. Closing it properly means block-
-        // based invalidation in the shared cache, which is a wider change than
-        // this window justifies.
-        controllerAddress = await asyncCall(
-          `exitFee/controllerAddress/${RSK_CHAIN_ID}/${protocol.address}`,
-          () => getter.exitFeeController(),
-          { ttl: EXIT_FEE_TTL },
-        );
-      } catch (error) {
-        // The getter itself is missing or reverts, which is what a protocol
-        // without the perimeter looks like. Nothing is charged there, and the
-        // spec requires the forms to look exactly as they do today -- so this
-        // is a real answer of "no fee", not a failure to obtain one. It is
-        // also the state of mainnet until the activation SIPs execute.
-        return UNCHARGED;
-      }
-
-      if (!controllerAddress || controllerAddress === constants.AddressZero) {
-        // Perimeter deployed but not yet pinned: charges nothing by
-        // construction.
-        return UNCHARGED;
-      }
-
-      try {
-        const controller = new Contract(
-          controllerAddress,
-          CONTROLLER_ABI,
+        const getter = new Contract(
+          protocol.address,
+          CONTROLLER_GETTER_ABI,
           getProvider(RSK_CHAIN_ID),
         );
-        const [quote] = await controller.functions.quoteExitFee(
-          surfaceId,
-          subProduct,
-          account,
-          EXIT_FEE_REFERENCE_GROSS,
-        );
-        return {
-          active: quote.active,
-          rateBps: Number(quote.rateBps),
-          unknown: false,
-        };
-      } catch (error) {
-        // The pointer resolved, so the perimeter IS live and this call should
-        // have worked. A revert, RPC failure or decode error here means we do
-        // not know the rate -- and with a live perimeter that is not the same
-        // as the rate being zero.
-        return UNKNOWN;
-      }
-    },
+
+        let controllerAddress;
+        try {
+          // Negative-cached too: while undeployed this reverts and we cache the
+          // uncharged answer.
+          //
+          // Known and accepted: the pointer is cached for EXIT_FEE_TTL under a
+          // key with no block dimension, so at the moment governance pins the
+          // controller the app can report "no fee" for up to that long while the
+          // chain has started charging. The window is bounded, it exists once,
+          // and the release order already covers it -- the dapp ships before
+          // charging is enabled, never after. Closing it properly means block-
+          // based invalidation in the shared cache, which is a wider change than
+          // this window justifies.
+          controllerAddress = await asyncCall(
+            `exitFee/controllerAddress/${RSK_CHAIN_ID}/${protocol.address}`,
+            () => getter.exitFeeController(),
+            { ttl: EXIT_FEE_TTL },
+          );
+        } catch (error) {
+          // The getter itself is missing or reverts, which is what a protocol
+          // without the perimeter looks like. Nothing is charged there, and the
+          // spec requires the forms to look exactly as they do today -- so this
+          // is a real answer of "no fee", not a failure to obtain one. It is
+          // also the state of mainnet until the activation SIPs execute.
+          return UNCHARGED;
+        }
+
+        if (!controllerAddress || controllerAddress === constants.AddressZero) {
+          // Perimeter deployed but not yet pinned: charges nothing by
+          // construction.
+          return UNCHARGED;
+        }
+
+        try {
+          const controller = new Contract(
+            controllerAddress,
+            CONTROLLER_ABI,
+            getProvider(RSK_CHAIN_ID),
+          );
+          const [quote] = await controller.functions.quoteExitFee(
+            surfaceId,
+            subProduct,
+            account,
+            EXIT_FEE_REFERENCE_GROSS,
+          );
+          return {
+            active: quote.active,
+            rateBps: Number(quote.rateBps),
+            unknown: false,
+          };
+        } catch (error) {
+          // The pointer resolved, so the perimeter IS live and this call should
+          // have worked. A revert, RPC failure or decode error here means we do
+          // not know the rate -- and with a live perimeter that is not the same
+          // as the rate being zero.
+          return UNKNOWN;
+        }
+      }),
     [protocol?.address, surfaceId, subProduct, account],
-    UNKNOWN,
+    { ...UNKNOWN, forKey: '' },
     { ttl: EXIT_FEE_TTL },
   );
 
-  return useMemo(
-    () => ({
-      active: value.active,
-      rateBps: value.rateBps,
-      unknown: value.unknown,
-      loading,
-    }),
-    [value, loading],
-  );
+  return useMemo(() => {
+    // A value fetched for a different key is the previous account's or
+    // pool's answer. Report it as still loading, which the display treats
+    // as "nothing charged" — never as that other party's fee.
+    const fresh = value.forKey === key;
+    return {
+      active: fresh ? value.active : false,
+      rateBps: fresh ? value.rateBps : 0,
+      unknown: fresh ? value.unknown : true,
+      loading: loading || !fresh,
+    };
+  }, [value, loading, key]);
 };

--- a/apps/frontend/src/hooks/exitFee/useExitFeeRate.ts
+++ b/apps/frontend/src/hooks/exitFee/useExitFeeRate.ts
@@ -60,7 +60,13 @@ export const useExitFeeRate = (
   const { account } = useAccount();
   const protocol = useGetProtocolContract('protocol', RSK_CHAIN_ID);
 
-  const key = `exitFee/rate/${surfaceId}/${subProduct}/${account}`;
+  // The protocol contract loads asynchronously. Before it has, the fetcher
+  // answers UNCHARGED — and the shared cache keeps that answer for the TTL.
+  // If the key ignored readiness, the rerun triggered by the contract landing
+  // would hit that same fresh entry and a genuinely charged fee would stay
+  // hidden for up to 30 s after every page load. Keying on the address makes
+  // the pre-load answer live under its own key, so the loaded one is fetched.
+  const key = `exitFee/rate/${surfaceId}/${subProduct}/${account}/${protocol?.address}`;
 
   const { value, loading } = useCacheCall(
     key,

--- a/apps/frontend/src/hooks/exitFee/useExitFeeRate.ts
+++ b/apps/frontend/src/hooks/exitFee/useExitFeeRate.ts
@@ -91,13 +91,14 @@ export const useExitFeeRate = (
           // uncharged answer.
           //
           // Known and accepted: the pointer is cached for EXIT_FEE_TTL under a
-          // key with no block dimension, so at the moment governance pins the
-          // controller the app can report "no fee" for up to that long while the
-          // chain has started charging. The window is bounded, it exists once,
-          // and the release order already covers it -- the dapp ships before
+          // key with no block dimension, and a refetch only runs on the next
+          // observed block, so at the moment governance pins the controller an
+          // open client can report "no fee" for up to one TTL plus one block
+          // (about 60 s on RSK) while the chain has started charging. Bounded,
+          // one-time, and covered by the release order: the dapp ships before
           // charging is enabled, never after. Closing it properly means block-
-          // based invalidation in the shared cache, which is a wider change than
-          // this window justifies.
+          // based invalidation in the shared cache, a wider change than this
+          // window justifies.
           controllerAddress = await asyncCall(
             `exitFee/controllerAddress/${RSK_CHAIN_ID}/${protocol.address}`,
             () => getter.exitFeeController(),

--- a/apps/frontend/src/hooks/exitFee/useExitFeeRate.ts
+++ b/apps/frontend/src/hooks/exitFee/useExitFeeRate.ts
@@ -47,17 +47,21 @@ export const useExitFeeRate = (
     RSK_CHAIN_ID,
     async () => {
       if (!protocol || !subProduct || !account) {
-        // Nothing was asked, so nothing is known.
-        return UNKNOWN;
+        // Nothing to quote against yet. The spec's rule for every such case is
+        // that the form looks exactly as it does without the perimeter.
+        return UNCHARGED;
       }
+
+      const getter = new Contract(
+        protocol.address,
+        CONTROLLER_GETTER_ABI,
+        getProvider(RSK_CHAIN_ID),
+      );
+
+      let controllerAddress;
       try {
-        const getter = new Contract(
-          protocol.address,
-          CONTROLLER_GETTER_ABI,
-          getProvider(RSK_CHAIN_ID),
-        );
-        // Negative-cached too: while undeployed this reverts and we cache
-        // UNKNOWN.
+        // Negative-cached too: while undeployed this reverts and we cache the
+        // uncharged answer.
         //
         // Known and accepted: the pointer is cached for EXIT_FEE_TTL under a
         // key with no block dimension, so at the moment governance pins the
@@ -67,14 +71,27 @@ export const useExitFeeRate = (
         // charging is enabled, never after. Closing it properly means block-
         // based invalidation in the shared cache, which is a wider change than
         // this window justifies.
-        const controllerAddress: string = await asyncCall(
+        controllerAddress = await asyncCall(
           `exitFee/controllerAddress/${RSK_CHAIN_ID}/${protocol.address}`,
           () => getter.exitFeeController(),
           { ttl: EXIT_FEE_TTL },
         );
-        if (!controllerAddress || controllerAddress === constants.AddressZero) {
-          return UNCHARGED;
-        }
+      } catch (error) {
+        // The getter itself is missing or reverts, which is what a protocol
+        // without the perimeter looks like. Nothing is charged there, and the
+        // spec requires the forms to look exactly as they do today -- so this
+        // is a real answer of "no fee", not a failure to obtain one. It is
+        // also the state of mainnet until the activation SIPs execute.
+        return UNCHARGED;
+      }
+
+      if (!controllerAddress || controllerAddress === constants.AddressZero) {
+        // Perimeter deployed but not yet pinned: charges nothing by
+        // construction.
+        return UNCHARGED;
+      }
+
+      try {
         const controller = new Contract(
           controllerAddress,
           CONTROLLER_ABI,
@@ -92,8 +109,10 @@ export const useExitFeeRate = (
           unknown: false,
         };
       } catch (error) {
-        // Reverts, RPC failures and decode errors land here alike. Every one of
-        // them means we do not know the rate -- not that the rate is zero.
+        // The pointer resolved, so the perimeter IS live and this call should
+        // have worked. A revert, RPC failure or decode error here means we do
+        // not know the rate -- and with a live perimeter that is not the same
+        // as the rate being zero.
         return UNKNOWN;
       }
     },

--- a/apps/frontend/src/hooks/exitFee/useExitFeeRate.ts
+++ b/apps/frontend/src/hooks/exitFee/useExitFeeRate.ts
@@ -7,18 +7,25 @@ import { getProvider } from '@sovryn/ethers-provider';
 import { RSK_CHAIN_ID } from '../../config/chains';
 
 import { asyncCall } from '../../store/rxjs/provider-cache';
-import { EXIT_FEE_REFERENCE_GROSS, EXIT_FEE_TTL } from '../../utils/exitFee';
+import {
+  EXIT_FEE_REFERENCE_GROSS,
+  EXIT_FEE_TTL,
+  ExitFeeQuote,
+} from '../../utils/exitFee';
 import { useAccount } from '../useAccount';
 import { useCacheCall } from '../useCacheCall';
 import { useGetProtocolContract } from '../useGetContract';
 
-export type ExitFeeRate = {
-  active: boolean;
-  rateBps: number;
-  loading: boolean;
-};
+export type ExitFeeRate = ExitFeeQuote;
 
-const INACTIVE = { active: false, rateBps: 0 };
+/** No quote obtained. Renders as "unavailable", never as "no fee". */
+const UNKNOWN = { active: false, rateBps: 0, unknown: true };
+/**
+ * A real answer of "nothing is charged": the protocol holds no controller
+ * pointer, so the on-chain path charges nothing by construction. This is a
+ * fact, not a failure, and must not be shown as unavailable.
+ */
+const UNCHARGED = { active: false, rateBps: 0, unknown: false };
 
 const CONTROLLER_GETTER_ABI = [
   'function exitFeeController() view returns (address)',
@@ -40,7 +47,8 @@ export const useExitFeeRate = (
     RSK_CHAIN_ID,
     async () => {
       if (!protocol || !subProduct || !account) {
-        return INACTIVE;
+        // Nothing was asked, so nothing is known.
+        return UNKNOWN;
       }
       try {
         const getter = new Contract(
@@ -48,14 +56,14 @@ export const useExitFeeRate = (
           CONTROLLER_GETTER_ABI,
           getProvider(RSK_CHAIN_ID),
         );
-        // negative-cached too: while undeployed this reverts and we cache INACTIVE
+        // negative-cached too: while undeployed this reverts and we cache UNKNOWN
         const controllerAddress: string = await asyncCall(
           `exitFee/controllerAddress/${RSK_CHAIN_ID}/${protocol.address}`,
           () => getter.exitFeeController(),
           { ttl: EXIT_FEE_TTL },
         );
         if (!controllerAddress || controllerAddress === constants.AddressZero) {
-          return INACTIVE;
+          return UNCHARGED;
         }
         const controller = new Contract(
           controllerAddress,
@@ -68,18 +76,29 @@ export const useExitFeeRate = (
           account,
           EXIT_FEE_REFERENCE_GROSS,
         );
-        return { active: quote.active, rateBps: Number(quote.rateBps) };
+        return {
+          active: quote.active,
+          rateBps: Number(quote.rateBps),
+          unknown: false,
+        };
       } catch (error) {
-        return INACTIVE;
+        // Reverts, RPC failures and decode errors land here alike. Every one of
+        // them means we do not know the rate -- not that the rate is zero.
+        return UNKNOWN;
       }
     },
     [protocol?.address, surfaceId, subProduct, account],
-    INACTIVE,
+    UNKNOWN,
     { ttl: EXIT_FEE_TTL },
   );
 
   return useMemo(
-    () => ({ active: value.active, rateBps: value.rateBps, loading }),
+    () => ({
+      active: value.active,
+      rateBps: value.rateBps,
+      unknown: value.unknown,
+      loading,
+    }),
     [value, loading],
   );
 };

--- a/apps/frontend/src/hooks/exitFee/useExitFeeRate.ts
+++ b/apps/frontend/src/hooks/exitFee/useExitFeeRate.ts
@@ -56,7 +56,17 @@ export const useExitFeeRate = (
           CONTROLLER_GETTER_ABI,
           getProvider(RSK_CHAIN_ID),
         );
-        // negative-cached too: while undeployed this reverts and we cache UNKNOWN
+        // Negative-cached too: while undeployed this reverts and we cache
+        // UNKNOWN.
+        //
+        // Known and accepted: the pointer is cached for EXIT_FEE_TTL under a
+        // key with no block dimension, so at the moment governance pins the
+        // controller the app can report "no fee" for up to that long while the
+        // chain has started charging. The window is bounded, it exists once,
+        // and the release order already covers it -- the dapp ships before
+        // charging is enabled, never after. Closing it properly means block-
+        // based invalidation in the shared cache, which is a wider change than
+        // this window justifies.
         const controllerAddress: string = await asyncCall(
           `exitFee/controllerAddress/${RSK_CHAIN_ID}/${protocol.address}`,
           () => getter.exitFeeController(),

--- a/apps/frontend/src/hooks/exitFee/useZeroExitFee.test.ts
+++ b/apps/frontend/src/hooks/exitFee/useZeroExitFee.test.ts
@@ -4,19 +4,20 @@ import { BigNumber } from 'ethers';
 
 import { Decimal } from '@sovryn/utils';
 
+import { getExitFeeDisplay } from '../../utils/exitFee';
 import { useZeroExitFee } from './useZeroExitFee';
 
 /**
- * The preview FAILS OPEN. It does not revert when it cannot obtain a usable
- * quote — it returns normally, with `active: false`, a zero fee, and a `reason`
- * saying why. So a hook that reads `active` alone reports "nothing is charged"
- * for a controller it could not reach, and on the Zero views that renders the
- * GROSS as the amount the user will receive.
+ * The preview FAILS OPEN, and so does the live charge: when the contract cannot
+ * obtain a usable quote it returns normally with `active: false`, a zero fee
+ * and the reason — and at execution the same path charges nothing and pays the
+ * gross. So for every reason the contract can report, the truthful display is
+ * the same: no fee taken, no fee shown, the form as it was before the
+ * perimeter existed.
  *
- * These tests exist to keep that distinction. They drive the hook with
- * successful calls that carry each reason, which is the shape the contract
- * actually produces — a throwing mock would exercise the other, already-covered
- * path and prove nothing about this one.
+ * These tests drive the hook with SUCCESSFUL calls carrying each reason, which
+ * is the shape the contract actually produces; a throwing mock exercises the
+ * other, already-covered path and proves nothing about this one.
  */
 
 const REASON = {
@@ -143,33 +144,14 @@ describe('useZeroExitFee', () => {
   });
 
   it.each([
-    ['the controller could not be reached', REASON.CONTROLLER_REVERT],
-    ['the quote came back unusable', REASON.INVALID_QUOTE],
-    ['the vault leg reported a failure', REASON.VAULT_REVERT],
-  ])(
-    'reports UNKNOWN, not a zero fee, when %s',
-    async (_label, reason) => {
-      // The call SUCCEEDS and hands back net == gross. Reading `active` alone
-      // would render that gross as the receivable amount.
-      mockPreview.mockResolvedValue(
-        previewResult(reason, { netAmount: '1000000000000000000' }),
-      );
-
-      const { result } = renderHook(() => useZeroExitFee(Decimal.from(1)));
-
-      await waitFor(() => expect(result.current.loading).toBe(false));
-      // The catch-all returns this same shape, so assert we got here by
-      // CLASSIFYING a successful preview rather than by throwing on the way.
-      expect(mockPreview).toHaveBeenCalled();
-      expect(result.current.unknown).toBe(true);
-      expect(result.current.active).toBe(false);
-    },
-  );
-
-  it.each([
     ['charging is switched off globally', REASON.INACTIVE],
     ['the surface carries no policy', REASON.DISABLED],
-  ])('reports a settled no-fee answer when %s', async (_label, reason) => {
+    ['the quote came back unusable', REASON.INVALID_QUOTE],
+    ['the controller could not be reached', REASON.CONTROLLER_REVERT],
+    ['the vault leg reported a failure', REASON.VAULT_REVERT],
+  ])('shows no fee when %s — the chain charges none', async (_label, reason) => {
+    // The call SUCCEEDS and hands back net == gross: that is the contract
+    // saying the user receives the whole amount. The rows must stay hidden.
     mockPreview.mockResolvedValue(
       previewResult(reason, { netAmount: '1000000000000000000' }),
     );
@@ -177,8 +159,24 @@ describe('useZeroExitFee', () => {
     const { result } = renderHook(() => useZeroExitFee(Decimal.from(1)));
 
     await waitFor(() => expect(result.current.loading).toBe(false));
+    // A throw anywhere upstream also yields active=false, so prove we got
+    // here by classifying a successful preview rather than by failing early.
     expect(mockPreview).toHaveBeenCalled();
-    expect(result.current.unknown).toBe(false);
     expect(result.current.active).toBe(false);
+    expect(result.current.unknown).toBe(false);
+    expect(getExitFeeDisplay(result.current, result.current.feeAmount)).toBe(
+      'none',
+    );
+  });
+
+  it('shows no fee while the quote has not arrived', async () => {
+    mockPreview.mockReturnValue(new Promise(() => undefined)); // never settles
+
+    const { result } = renderHook(() => useZeroExitFee(Decimal.from(1)));
+
+    expect(result.current.loading).toBe(true);
+    expect(getExitFeeDisplay(result.current, result.current.feeAmount)).toBe(
+      'none',
+    );
   });
 });

--- a/apps/frontend/src/hooks/exitFee/useZeroExitFee.test.ts
+++ b/apps/frontend/src/hooks/exitFee/useZeroExitFee.test.ts
@@ -149,25 +149,28 @@ describe('useZeroExitFee', () => {
     ['the quote came back unusable', REASON.INVALID_QUOTE],
     ['the controller could not be reached', REASON.CONTROLLER_REVERT],
     ['the vault leg reported a failure', REASON.VAULT_REVERT],
-  ])('shows no fee when %s — the chain charges none', async (_label, reason) => {
-    // The call SUCCEEDS and hands back net == gross: that is the contract
-    // saying the user receives the whole amount. The rows must stay hidden.
-    mockPreview.mockResolvedValue(
-      previewResult(reason, { netAmount: '1000000000000000000' }),
-    );
+  ])(
+    'shows no fee when %s — the chain charges none',
+    async (_label, reason) => {
+      // The call SUCCEEDS and hands back net == gross: that is the contract
+      // saying the user receives the whole amount. The rows must stay hidden.
+      mockPreview.mockResolvedValue(
+        previewResult(reason, { netAmount: '1000000000000000000' }),
+      );
 
-    const { result } = renderHook(() => useZeroExitFee(Decimal.from(1)));
+      const { result } = renderHook(() => useZeroExitFee(Decimal.from(1)));
 
-    await waitFor(() => expect(result.current.loading).toBe(false));
-    // A throw anywhere upstream also yields active=false, so prove we got
-    // here by classifying a successful preview rather than by failing early.
-    expect(mockPreview).toHaveBeenCalled();
-    expect(result.current.active).toBe(false);
-    expect(result.current.unknown).toBe(false);
-    expect(getExitFeeDisplay(result.current, result.current.feeAmount)).toBe(
-      'none',
-    );
-  });
+      await waitFor(() => expect(result.current.loading).toBe(false));
+      // A throw anywhere upstream also yields active=false, so prove we got
+      // here by classifying a successful preview rather than by failing early.
+      expect(mockPreview).toHaveBeenCalled();
+      expect(result.current.active).toBe(false);
+      expect(result.current.unknown).toBe(false);
+      expect(getExitFeeDisplay(result.current, result.current.feeAmount)).toBe(
+        'none',
+      );
+    },
+  );
 
   it('shows no fee while the quote has not arrived', async () => {
     mockPreview.mockReturnValue(new Promise(() => undefined)); // never settles

--- a/apps/frontend/src/hooks/exitFee/useZeroExitFee.test.ts
+++ b/apps/frontend/src/hooks/exitFee/useZeroExitFee.test.ts
@@ -1,0 +1,184 @@
+import { renderHook, waitFor } from '@testing-library/react';
+
+import { BigNumber } from 'ethers';
+
+import { Decimal } from '@sovryn/utils';
+
+import { useZeroExitFee } from './useZeroExitFee';
+
+/**
+ * The preview FAILS OPEN. It does not revert when it cannot obtain a usable
+ * quote — it returns normally, with `active: false`, a zero fee, and a `reason`
+ * saying why. So a hook that reads `active` alone reports "nothing is charged"
+ * for a controller it could not reach, and on the Zero views that renders the
+ * GROSS as the amount the user will receive.
+ *
+ * These tests exist to keep that distinction. They drive the hook with
+ * successful calls that carry each reason, which is the shape the contract
+ * actually produces — a throwing mock would exercise the other, already-covered
+ * path and prove nothing about this one.
+ */
+
+const REASON = {
+  NONE: 0,
+  INACTIVE: 1,
+  DISABLED: 2,
+  INVALID_QUOTE: 3,
+  CONTROLLER_REVERT: 4,
+  VAULT_REVERT: 5,
+};
+
+const CONTROLLER = '0x99994b4522483DE17F31a5bC010c5901AdD3440E';
+const BORROWER_OPERATIONS = '0x5B9dB4B8bdeF3e57323187a9AC2639C5DEe5FD39';
+
+const mockPreview = jest.fn();
+const mockControllerPointer = jest.fn();
+const mockZeroContract = jest.fn();
+
+// create-react-app's jest preset sets `resetMocks: true`, which strips the
+// implementation off every mock before each test. So the module factories below
+// must be plain functions that DELEGATE to jest.fn()s wired up in beforeEach —
+// an implementation attached here would be gone by the time a test runs, and
+// the hook would fall into its catch on every case.
+jest.mock('ethers', () => {
+  const actual = jest.requireActual('ethers');
+  return {
+    ...actual,
+    Contract: function (_address: string, abi: unknown) {
+      return JSON.stringify(abi).includes('previewZeroCollWithdrawExitFee')
+        ? {
+            previewZeroCollWithdrawExitFee: (...args: unknown[]) =>
+              mockPreview(...args),
+          }
+        : { exitFeeController: () => mockControllerPointer() };
+    },
+  };
+});
+
+jest.mock('@sovryn/contracts', () => ({
+  getZeroContract: (...args: unknown[]) => mockZeroContract(...args),
+}));
+
+jest.mock('@sovryn/ethers-provider', () => ({
+  getProvider: () => ({}),
+}));
+
+jest.mock('../../utils/chain', () => ({
+  getRskChainId: () => '0x1e',
+}));
+
+jest.mock('../../store/rxjs/provider-cache', () => ({
+  asyncCall: (_key: string, fn: () => unknown) => fn(),
+}));
+
+jest.mock('../useAccount', () => ({
+  useAccount: () => ({ account: '0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266' }),
+}));
+
+// Stand-in for the shared cache: runs the fetcher once and reports the result,
+// so these tests measure the hook's own classification and nothing else.
+jest.mock('../useCacheCall', () => {
+  const React = jest.requireActual('react');
+  return {
+    useCacheCall: (
+      _key: string,
+      _chainId: string,
+      fn: () => Promise<unknown>,
+      _deps: unknown[],
+      defaultValue: unknown,
+    ) => {
+      const [state, setState] = React.useState({
+        value: defaultValue,
+        loading: true,
+      });
+      React.useEffect(() => {
+        let alive = true;
+        Promise.resolve(fn()).then((value: unknown) => {
+          if (alive) setState({ value, loading: false });
+        });
+        return () => {
+          alive = false;
+        };
+      }, []);
+      return state;
+    },
+  };
+});
+
+/** A preview return in the contract's own shape. */
+const previewResult = (
+  reason: number,
+  { active = false, rateBps = 0, feeAmount = '0', netAmount = '0' } = {},
+) => ({
+  rateBps,
+  feeAmount: BigNumber.from(feeAmount),
+  netAmount: BigNumber.from(netAmount),
+  feeReceiver: '0xDDE75f75ff33Aa802f2316cCAe2bE77823fc6f9B',
+  active,
+  reason,
+});
+
+describe('useZeroExitFee', () => {
+  beforeEach(() => {
+    mockZeroContract.mockResolvedValue({ address: BORROWER_OPERATIONS });
+    mockControllerPointer.mockResolvedValue(CONTROLLER);
+  });
+
+  it('reports a live charge when the quote resolves', async () => {
+    mockPreview.mockResolvedValue(
+      previewResult(REASON.NONE, {
+        active: true,
+        rateBps: 10,
+        feeAmount: '1000000000000000',
+        netAmount: '999000000000000000',
+      }),
+    );
+
+    const { result } = renderHook(() => useZeroExitFee(Decimal.from(1)));
+
+    await waitFor(() => expect(result.current.loading).toBe(false));
+    expect(result.current.active).toBe(true);
+    expect(result.current.rateBps).toBe(10);
+    expect(result.current.unknown).toBe(false);
+  });
+
+  it.each([
+    ['the controller could not be reached', REASON.CONTROLLER_REVERT],
+    ['the quote came back unusable', REASON.INVALID_QUOTE],
+    ['the vault leg reported a failure', REASON.VAULT_REVERT],
+  ])(
+    'reports UNKNOWN, not a zero fee, when %s',
+    async (_label, reason) => {
+      // The call SUCCEEDS and hands back net == gross. Reading `active` alone
+      // would render that gross as the receivable amount.
+      mockPreview.mockResolvedValue(
+        previewResult(reason, { netAmount: '1000000000000000000' }),
+      );
+
+      const { result } = renderHook(() => useZeroExitFee(Decimal.from(1)));
+
+      await waitFor(() => expect(result.current.loading).toBe(false));
+      // The catch-all returns this same shape, so assert we got here by
+      // CLASSIFYING a successful preview rather than by throwing on the way.
+      expect(mockPreview).toHaveBeenCalled();
+      expect(result.current.unknown).toBe(true);
+      expect(result.current.active).toBe(false);
+    },
+  );
+
+  it.each([
+    ['charging is switched off globally', REASON.INACTIVE],
+    ['the surface carries no policy', REASON.DISABLED],
+  ])('reports a settled no-fee answer when %s', async (_label, reason) => {
+    mockPreview.mockResolvedValue(
+      previewResult(reason, { netAmount: '1000000000000000000' }),
+    );
+
+    const { result } = renderHook(() => useZeroExitFee(Decimal.from(1)));
+
+    await waitFor(() => expect(result.current.loading).toBe(false));
+    expect(mockPreview).toHaveBeenCalled();
+    expect(result.current.unknown).toBe(false);
+    expect(result.current.active).toBe(false);
+  });
+});

--- a/apps/frontend/src/hooks/exitFee/useZeroExitFee.ts
+++ b/apps/frontend/src/hooks/exitFee/useZeroExitFee.ts
@@ -1,11 +1,12 @@
 import { useMemo } from 'react';
 
-import { Contract } from 'ethers';
+import { Contract, constants } from 'ethers';
 
 import { getZeroContract } from '@sovryn/contracts';
 import { getProvider } from '@sovryn/ethers-provider';
 import { Decimal } from '@sovryn/utils';
 
+import { asyncCall } from '../../store/rxjs/provider-cache';
 import { getRskChainId } from '../../utils/chain';
 import {
   EXIT_FEE_REFERENCE_GROSS,
@@ -29,6 +30,10 @@ const INACTIVE = {
 };
 
 // The Z-1 kept preview — same _safeQuote path as the live charge hook.
+const CONTROLLER_GETTER_ABI = [
+  'function exitFeeController() view returns (address)',
+];
+
 const PREVIEW_ABI = [
   'function previewZeroCollWithdrawExitFee(address borrower, uint256 grossColl) view returns (uint16 rateBps, uint256 feeAmount, uint256 netAmount, address feeReceiver, bool active, uint8 reason)',
 ];
@@ -64,6 +69,32 @@ export const useZeroExitFee = (gross?: Decimal): ZeroExitFee => {
           'borrowerOperations',
           getRskChainId(),
         );
+        /**
+         * Same split as the lending hook. A missing or reverting
+         * `exitFeeController()` is what Zero looks like before the perimeter
+         * ships: nothing is charged, and the form must look untouched. Only
+         * once that pointer resolves does a failing preview mean we genuinely
+         * do not know the rate.
+         */
+        const pointer = new Contract(
+          address,
+          CONTROLLER_GETTER_ABI,
+          getProvider(getRskChainId()),
+        );
+        let controllerAddress;
+        try {
+          controllerAddress = await asyncCall(
+            `exitFee/zeroController/${getRskChainId()}/${address}`,
+            () => pointer.exitFeeController(),
+            { ttl: EXIT_FEE_TTL },
+          );
+        } catch (error) {
+          return INACTIVE;
+        }
+        if (!controllerAddress || controllerAddress === constants.AddressZero) {
+          return INACTIVE;
+        }
+
         const borrowerOperations = new Contract(
           address,
           PREVIEW_ABI,

--- a/apps/frontend/src/hooks/exitFee/useZeroExitFee.ts
+++ b/apps/frontend/src/hooks/exitFee/useZeroExitFee.ts
@@ -29,6 +29,17 @@ const INACTIVE = {
   unknown: false,
 };
 
+/**
+ * Stamp a fetched quote with the cache key it was fetched FOR. The shared
+ * cache keeps its previous state until a changed key's result lands, so on
+ * the first render after an account or gross switch `value` still belongs to
+ * the old key. Only a quote whose stamp matches the current key is displayed.
+ */
+const stamped = async <T extends object>(
+  forKey: string,
+  fetch: () => Promise<T>,
+) => ({ ...(await fetch()), forKey });
+
 // The Z-1 kept preview — same _safeQuote path as the live charge hook.
 const CONTROLLER_GETTER_ABI = [
   'function exitFeeController() view returns (address)',
@@ -50,82 +61,94 @@ export const useZeroExitFee = (gross?: Decimal): ZeroExitFee => {
     return gross.isZero() ? null : gross.toBigNumber().toString();
   }, [gross]);
 
-  const { value, loading } = useCacheCall(
-    `exitFee/zero/${account}/${grossWei}`,
-    getRskChainId(),
-    async () => {
-      if (grossWei === null) {
-        // An explicit zero gross: nothing leaves, so no fee can be charged.
-        // That is a real answer, not a failure to get one -- reporting it as
-        // unknown would put "fee unavailable" on every add-collateral and
-        // borrow form, where no exit is happening at all.
-        return INACTIVE;
-      }
-      if (!account) {
-        return { ...INACTIVE, unknown: true };
-      }
-      try {
-        const { address } = await getZeroContract(
-          'borrowerOperations',
-          getRskChainId(),
-        );
-        /**
-         * Same split as the lending hook. A missing or reverting
-         * `exitFeeController()` is what Zero looks like before the perimeter
-         * ships: nothing is charged, and the form must look untouched. Only
-         * once that pointer resolves does a failing preview mean we genuinely
-         * do not know the rate.
-         */
-        const pointer = new Contract(
-          address,
-          CONTROLLER_GETTER_ABI,
-          getProvider(getRskChainId()),
-        );
-        let controllerAddress;
-        try {
-          controllerAddress = await asyncCall(
-            `exitFee/zeroController/${getRskChainId()}/${address}`,
-            () => pointer.exitFeeController(),
-            { ttl: EXIT_FEE_TTL },
-          );
-        } catch (error) {
-          return INACTIVE;
-        }
-        if (!controllerAddress || controllerAddress === constants.AddressZero) {
-          return INACTIVE;
-        }
+  const key = `exitFee/zero/${account}/${grossWei}`;
 
-        const borrowerOperations = new Contract(
-          address,
-          PREVIEW_ABI,
-          getProvider(getRskChainId()),
-        );
-        const result = await borrowerOperations.previewZeroCollWithdrawExitFee(
-          account,
-          grossWei,
-        );
-        // The preview fails OPEN, exactly as the live charge does: when the
-        // controller is unreachable or hands back an unusable quote it returns
-        // active=false with a zero fee, and at execution the same path charges
-        // nothing and pays the gross. So `active=false` here IS the answer —
-        // no fee is taken — and the rows stay hidden. The reason is not
-        // consulted: whichever it is, the user receives the whole amount.
-        return {
-          active: result.active,
-          rateBps: Number(result.rateBps),
-          feeAmount: Decimal.fromBigNumberString(result.feeAmount.toString()),
-          netAmount: Decimal.fromBigNumberString(result.netAmount.toString()),
-          unknown: false,
-        };
-      } catch (error) {
-        // Same rule as the lending hook: a failed preview is not a zero fee.
-        return { ...INACTIVE, unknown: true };
-      }
-    },
+  const { value, loading } = useCacheCall(
+    key,
+    getRskChainId(),
+    () =>
+      stamped(key, async () => {
+        if (grossWei === null) {
+          // An explicit zero gross: nothing leaves, so no fee can be charged.
+          return INACTIVE;
+        }
+        if (!account) {
+          return { ...INACTIVE, unknown: true };
+        }
+        try {
+          const { address } = await getZeroContract(
+            'borrowerOperations',
+            getRskChainId(),
+          );
+          /**
+           * Same split as the lending hook. A missing or reverting
+           * `exitFeeController()` is what Zero looks like before the perimeter
+           * ships: nothing is charged, and the form must look untouched. Only
+           * once that pointer resolves does a failing preview mean we genuinely
+           * do not know the rate.
+           */
+          const pointer = new Contract(
+            address,
+            CONTROLLER_GETTER_ABI,
+            getProvider(getRskChainId()),
+          );
+          let controllerAddress;
+          try {
+            controllerAddress = await asyncCall(
+              `exitFee/zeroController/${getRskChainId()}/${address}`,
+              () => pointer.exitFeeController(),
+              { ttl: EXIT_FEE_TTL },
+            );
+          } catch (error) {
+            return INACTIVE;
+          }
+          if (
+            !controllerAddress ||
+            controllerAddress === constants.AddressZero
+          ) {
+            return INACTIVE;
+          }
+
+          const borrowerOperations = new Contract(
+            address,
+            PREVIEW_ABI,
+            getProvider(getRskChainId()),
+          );
+          const result =
+            await borrowerOperations.previewZeroCollWithdrawExitFee(
+              account,
+              grossWei,
+            );
+          // The preview fails OPEN, exactly as the live charge does: when the
+          // controller is unreachable or hands back an unusable quote it returns
+          // active=false with a zero fee, and at execution the same path charges
+          // nothing and pays the gross. So `active=false` here IS the answer —
+          // no fee is taken — and the rows stay hidden. The reason is not
+          // consulted: whichever it is, the user receives the whole amount.
+          return {
+            active: result.active,
+            rateBps: Number(result.rateBps),
+            feeAmount: Decimal.fromBigNumberString(result.feeAmount.toString()),
+            netAmount: Decimal.fromBigNumberString(result.netAmount.toString()),
+            unknown: false,
+          };
+        } catch (error) {
+          // The preview itself could not be called. `unknown` records that for
+          // the consumers, and every consumer hides the rows for it: the chain
+          // fails open, so nothing is charged and the gross is paid.
+          return { ...INACTIVE, unknown: true };
+        }
+      }),
     [account, grossWei],
-    INACTIVE,
+    { ...INACTIVE, forKey: '' },
     { ttl: EXIT_FEE_TTL },
   );
 
-  return useMemo(() => ({ ...value, loading }), [value, loading]);
+  return useMemo(() => {
+    // A value fetched for a different key belongs to the previous account or
+    // gross. Report it as still loading — displayed as nothing charged — rather
+    // than showing that other quote's numbers for one frame.
+    const fresh = value.forKey === key;
+    return fresh ? { ...value, loading } : { ...INACTIVE, loading: true };
+  }, [value, loading, key]);
 };

--- a/apps/frontend/src/hooks/exitFee/useZeroExitFee.ts
+++ b/apps/frontend/src/hooks/exitFee/useZeroExitFee.ts
@@ -38,19 +38,6 @@ const PREVIEW_ABI = [
   'function previewZeroCollWithdrawExitFee(address borrower, uint256 grossColl) view returns (uint16 rateBps, uint256 feeAmount, uint256 netAmount, address feeReceiver, bool active, uint8 reason)',
 ];
 
-/**
- * `SkipReason` values that mean the quote could not be determined, as opposed
- * to a settled answer of "nothing is charged".
- *
- * 0 NONE and 1 INACTIVE and 2 DISABLED are real answers: the policy resolved,
- * or charging is switched off. 3 INVALID_QUOTE and 4 CONTROLLER_REVERT are the
- * fail-open paths — the hook could not obtain a usable quote and the contract
- * said so rather than reverting. 5 VAULT_REVERT belongs to the charging path
- * and cannot reach a view call, but it is listed because if it ever did, it
- * would likewise not be a rate we can show.
- */
-const UNDETERMINED_REASONS = [3, 4, 5];
-
 export const useZeroExitFee = (gross?: Decimal): ZeroExitFee => {
   const { account } = useAccount();
 
@@ -117,15 +104,12 @@ export const useZeroExitFee = (gross?: Decimal): ZeroExitFee => {
           account,
           grossWei,
         );
-        // The preview FAILS OPEN: when the controller is unreachable or hands
-        // back an unusable quote it does not revert, it returns normally with
-        // active=false, a zero fee and the reason why. Trusting `active` alone
-        // therefore turns "we could not ask" into "nothing is charged" — and on
-        // the Zero views that prints the GROSS as the amount you will receive,
-        // which is exactly what does not arrive (spec §3, revised 2026-08-21).
-        if (UNDETERMINED_REASONS.includes(Number(result.reason))) {
-          return { ...INACTIVE, unknown: true };
-        }
+        // The preview fails OPEN, exactly as the live charge does: when the
+        // controller is unreachable or hands back an unusable quote it returns
+        // active=false with a zero fee, and at execution the same path charges
+        // nothing and pays the gross. So `active=false` here IS the answer —
+        // no fee is taken — and the rows stay hidden. The reason is not
+        // consulted: whichever it is, the user receives the whole amount.
         return {
           active: result.active,
           rateBps: Number(result.rateBps),

--- a/apps/frontend/src/hooks/exitFee/useZeroExitFee.ts
+++ b/apps/frontend/src/hooks/exitFee/useZeroExitFee.ts
@@ -1,0 +1,83 @@
+import { useMemo } from 'react';
+
+import { Contract } from 'ethers';
+
+import { getZeroContract } from '@sovryn/contracts';
+import { getProvider } from '@sovryn/ethers-provider';
+import { Decimal } from '@sovryn/utils';
+
+import { getRskChainId } from '../../utils/chain';
+import { EXIT_FEE_REFERENCE_GROSS, EXIT_FEE_TTL } from '../../utils/exitFee';
+import { useAccount } from '../useAccount';
+import { useCacheCall } from '../useCacheCall';
+
+export type ZeroExitFee = {
+  active: boolean;
+  rateBps: number;
+  feeAmount: Decimal;
+  netAmount: Decimal;
+  loading: boolean;
+};
+
+const INACTIVE = {
+  active: false,
+  rateBps: 0,
+  feeAmount: Decimal.ZERO,
+  netAmount: Decimal.ZERO,
+};
+
+// The Z-1 kept preview — same _safeQuote path as the live charge hook.
+const PREVIEW_ABI = [
+  'function previewZeroCollWithdrawExitFee(address borrower, uint256 grossColl) view returns (uint16 rateBps, uint256 feeAmount, uint256 netAmount, address feeReceiver, bool active, uint8 reason)',
+];
+
+export const useZeroExitFee = (gross?: Decimal): ZeroExitFee => {
+  const { account } = useAccount();
+
+  const grossWei = useMemo(() => {
+    if (gross === undefined) {
+      return EXIT_FEE_REFERENCE_GROSS; // rate-only mode
+    }
+    // provided-but-zero gross: quoting the reference here would fabricate
+    // numbers for consumers that display the quote directly — stay inactive.
+    return gross.isZero() ? null : gross.toBigNumber().toString();
+  }, [gross]);
+
+  const { value, loading } = useCacheCall(
+    `exitFee/zero/${account}/${grossWei}`,
+    getRskChainId(),
+    async () => {
+      if (!account || grossWei === null) {
+        return INACTIVE;
+      }
+      try {
+        const { address } = await getZeroContract(
+          'borrowerOperations',
+          getRskChainId(),
+        );
+        const borrowerOperations = new Contract(
+          address,
+          PREVIEW_ABI,
+          getProvider(getRskChainId()),
+        );
+        const result = await borrowerOperations.previewZeroCollWithdrawExitFee(
+          account,
+          grossWei,
+        );
+        return {
+          active: result.active,
+          rateBps: Number(result.rateBps),
+          feeAmount: Decimal.fromBigNumberString(result.feeAmount.toString()),
+          netAmount: Decimal.fromBigNumberString(result.netAmount.toString()),
+        };
+      } catch (error) {
+        return INACTIVE;
+      }
+    },
+    [account, grossWei],
+    INACTIVE,
+    { ttl: EXIT_FEE_TTL },
+  );
+
+  return useMemo(() => ({ ...value, loading }), [value, loading]);
+};

--- a/apps/frontend/src/hooks/exitFee/useZeroExitFee.ts
+++ b/apps/frontend/src/hooks/exitFee/useZeroExitFee.ts
@@ -49,7 +49,14 @@ export const useZeroExitFee = (gross?: Decimal): ZeroExitFee => {
     `exitFee/zero/${account}/${grossWei}`,
     getRskChainId(),
     async () => {
-      if (!account || grossWei === null) {
+      if (grossWei === null) {
+        // An explicit zero gross: nothing leaves, so no fee can be charged.
+        // That is a real answer, not a failure to get one -- reporting it as
+        // unknown would put "fee unavailable" on every add-collateral and
+        // borrow form, where no exit is happening at all.
+        return INACTIVE;
+      }
+      if (!account) {
         return { ...INACTIVE, unknown: true };
       }
       try {

--- a/apps/frontend/src/hooks/exitFee/useZeroExitFee.ts
+++ b/apps/frontend/src/hooks/exitFee/useZeroExitFee.ts
@@ -7,16 +7,17 @@ import { getProvider } from '@sovryn/ethers-provider';
 import { Decimal } from '@sovryn/utils';
 
 import { getRskChainId } from '../../utils/chain';
-import { EXIT_FEE_REFERENCE_GROSS, EXIT_FEE_TTL } from '../../utils/exitFee';
+import {
+  EXIT_FEE_REFERENCE_GROSS,
+  EXIT_FEE_TTL,
+  ExitFeeQuote,
+} from '../../utils/exitFee';
 import { useAccount } from '../useAccount';
 import { useCacheCall } from '../useCacheCall';
 
-export type ZeroExitFee = {
-  active: boolean;
-  rateBps: number;
+export type ZeroExitFee = ExitFeeQuote & {
   feeAmount: Decimal;
   netAmount: Decimal;
-  loading: boolean;
 };
 
 const INACTIVE = {
@@ -24,6 +25,7 @@ const INACTIVE = {
   rateBps: 0,
   feeAmount: Decimal.ZERO,
   netAmount: Decimal.ZERO,
+  unknown: false,
 };
 
 // The Z-1 kept preview — same _safeQuote path as the live charge hook.
@@ -48,7 +50,7 @@ export const useZeroExitFee = (gross?: Decimal): ZeroExitFee => {
     getRskChainId(),
     async () => {
       if (!account || grossWei === null) {
-        return INACTIVE;
+        return { ...INACTIVE, unknown: true };
       }
       try {
         const { address } = await getZeroContract(
@@ -69,9 +71,11 @@ export const useZeroExitFee = (gross?: Decimal): ZeroExitFee => {
           rateBps: Number(result.rateBps),
           feeAmount: Decimal.fromBigNumberString(result.feeAmount.toString()),
           netAmount: Decimal.fromBigNumberString(result.netAmount.toString()),
+          unknown: false,
         };
       } catch (error) {
-        return INACTIVE;
+        // Same rule as the lending hook: a failed preview is not a zero fee.
+        return { ...INACTIVE, unknown: true };
       }
     },
     [account, grossWei],

--- a/apps/frontend/src/hooks/exitFee/useZeroExitFee.ts
+++ b/apps/frontend/src/hooks/exitFee/useZeroExitFee.ts
@@ -1,6 +1,6 @@
 import { useMemo } from 'react';
 
-import { Contract, constants } from 'ethers';
+import { Contract, constants, ethers } from 'ethers';
 
 import { getZeroContract } from '@sovryn/contracts';
 import { getProvider } from '@sovryn/ethers-provider';
@@ -9,6 +9,7 @@ import { Decimal } from '@sovryn/utils';
 import { asyncCall } from '../../store/rxjs/provider-cache';
 import { getRskChainId } from '../../utils/chain';
 import {
+  EXIT_FEE_MAX_BPS,
   EXIT_FEE_REFERENCE_GROSS,
   EXIT_FEE_TTL,
   ExitFeeQuote,
@@ -125,6 +126,19 @@ export const useZeroExitFee = (gross?: Decimal): ZeroExitFee => {
           // nothing and pays the gross. So `active=false` here IS the answer —
           // no fee is taken — and the rows stay hidden. The reason is not
           // consulted: whichever it is, the user receives the whole amount.
+          // A quote the chain itself would refuse is not one to display. The
+          // on-chain hook re-derives net from gross and fee and charges nothing
+          // when they disagree, so mirror that test here: an inconsistent
+          // preview — only a tampered RPC can produce one — hides the rows
+          // rather than printing a net the chain will not pay.
+          const gross = ethers.BigNumber.from(grossWei);
+          if (
+            result.feeAmount.gt(gross) ||
+            !result.netAmount.eq(gross.sub(result.feeAmount)) ||
+            Number(result.rateBps) > EXIT_FEE_MAX_BPS
+          ) {
+            return INACTIVE;
+          }
           return {
             active: result.active,
             rateBps: Number(result.rateBps),

--- a/apps/frontend/src/hooks/exitFee/useZeroExitFee.ts
+++ b/apps/frontend/src/hooks/exitFee/useZeroExitFee.ts
@@ -38,6 +38,19 @@ const PREVIEW_ABI = [
   'function previewZeroCollWithdrawExitFee(address borrower, uint256 grossColl) view returns (uint16 rateBps, uint256 feeAmount, uint256 netAmount, address feeReceiver, bool active, uint8 reason)',
 ];
 
+/**
+ * `SkipReason` values that mean the quote could not be determined, as opposed
+ * to a settled answer of "nothing is charged".
+ *
+ * 0 NONE and 1 INACTIVE and 2 DISABLED are real answers: the policy resolved,
+ * or charging is switched off. 3 INVALID_QUOTE and 4 CONTROLLER_REVERT are the
+ * fail-open paths — the hook could not obtain a usable quote and the contract
+ * said so rather than reverting. 5 VAULT_REVERT belongs to the charging path
+ * and cannot reach a view call, but it is listed because if it ever did, it
+ * would likewise not be a rate we can show.
+ */
+const UNDETERMINED_REASONS = [3, 4, 5];
+
 export const useZeroExitFee = (gross?: Decimal): ZeroExitFee => {
   const { account } = useAccount();
 
@@ -104,6 +117,15 @@ export const useZeroExitFee = (gross?: Decimal): ZeroExitFee => {
           account,
           grossWei,
         );
+        // The preview FAILS OPEN: when the controller is unreachable or hands
+        // back an unusable quote it does not revert, it returns normally with
+        // active=false, a zero fee and the reason why. Trusting `active` alone
+        // therefore turns "we could not ask" into "nothing is charged" — and on
+        // the Zero views that prints the GROSS as the amount you will receive,
+        // which is exactly what does not arrive (spec §3, revised 2026-08-21).
+        if (UNDETERMINED_REASONS.includes(Number(result.reason))) {
+          return { ...INACTIVE, unknown: true };
+        }
         return {
           active: result.active,
           rateBps: Number(result.rateBps),

--- a/apps/frontend/src/locales/en/translations.json
+++ b/apps/frontend/src/locales/en/translations.json
@@ -1673,9 +1673,7 @@
     "exitFee": {
         "label": "Perimeter fee ({{rate}}%)",
         "youWillReceive": "You will receive",
-        "tooltip": "The perimeter fee is deducted from the withdrawn amount when your transaction executes. Shown values are approximate — the final fee is determined at execution time.",
-        "unavailable": "Perimeter fee",
-        "unavailableTooltip": "The perimeter fee could not be read just now, so this amount is unknown — it does not mean no fee applies. The fee, if any, is still deducted when your transaction executes."
+        "tooltip": "The perimeter fee is deducted from the withdrawn amount when your transaction executes. Shown values are approximate — the final fee is determined at execution time."
     },
     "lending": {
         "title": "Deposit",

--- a/apps/frontend/src/locales/en/translations.json
+++ b/apps/frontend/src/locales/en/translations.json
@@ -1670,6 +1670,11 @@
         "currentBalance": "Current lending balance",
         "newBalance": "New lending balance"
     },
+    "exitFee": {
+        "label": "Perimeter fee ({{rate}}%)",
+        "youWillReceive": "You will receive",
+        "tooltip": "The perimeter fee is deducted from the withdrawn amount when your transaction executes. Shown values are approximate — the final fee is determined at execution time."
+    },
     "lending": {
         "title": "Deposit",
         "disclaimer": "I understand that the APR is variable and that there must be available liquidity in the pool for me to be able to withdraw my lending balance.",

--- a/apps/frontend/src/locales/en/translations.json
+++ b/apps/frontend/src/locales/en/translations.json
@@ -1673,7 +1673,9 @@
     "exitFee": {
         "label": "Perimeter fee ({{rate}}%)",
         "youWillReceive": "You will receive",
-        "tooltip": "The perimeter fee is deducted from the withdrawn amount when your transaction executes. Shown values are approximate — the final fee is determined at execution time."
+        "tooltip": "The perimeter fee is deducted from the withdrawn amount when your transaction executes. Shown values are approximate — the final fee is determined at execution time.",
+        "unavailable": "Perimeter fee",
+        "unavailableTooltip": "The perimeter fee could not be read just now, so this amount is unknown — it does not mean no fee applies. The fee, if any, is still deducted when your transaction executes."
     },
     "lending": {
         "title": "Deposit",

--- a/apps/frontend/src/utils/exitFee.test.ts
+++ b/apps/frontend/src/utils/exitFee.test.ts
@@ -1,0 +1,55 @@
+import { utils } from 'ethers';
+
+import { Decimal } from '@sovryn/utils';
+
+import {
+  EXIT_FEE_MAX_BPS,
+  SURFACE_LENDING_BORROWER_WITHDRAW,
+  SURFACE_LENDING_LENDER_WITHDRAW,
+  SURFACE_ZERO_CLAIM_SURPLUS,
+  getExitFeeAmount,
+  getExitFeeNet,
+  isExitFeeShown,
+} from './exitFee';
+
+describe('exitFee utils', () => {
+  it('surface ids match keccak256 of the registry preimages', () => {
+    expect(SURFACE_LENDING_LENDER_WITHDRAW).toEqual(
+      utils.id('COLFEE:SURFACE_LENDING_LENDER_WITHDRAW'),
+    );
+    expect(SURFACE_LENDING_BORROWER_WITHDRAW).toEqual(
+      utils.id('COLFEE:SURFACE_LENDING_BORROWER_WITHDRAW'),
+    );
+    expect(SURFACE_ZERO_CLAIM_SURPLUS).toEqual(
+      utils.id('COLFEE:SURFACE_ZERO_CLAIM_SURPLUS'),
+    );
+    // pin the literals so a typo in the preimage string cannot pass silently
+    expect(SURFACE_LENDING_LENDER_WITHDRAW).toEqual(
+      '0x3d0383a7986bf042db59f806aef31f95d28262f3280554c8541c299fa8e2ffb3',
+    );
+    expect(SURFACE_LENDING_BORROWER_WITHDRAW).toEqual(
+      '0x5c408ce1df6222b56e2084e292cdc734b880e9adbb4df2331d304431936967f7',
+    );
+    expect(SURFACE_ZERO_CLAIM_SURPLUS).toEqual(
+      '0xdd1d6592d9143b113f128998b830887d87bf784969f0bdeda154f2a49ca302e0',
+    );
+  });
+
+  it('computes fee and net in basis points', () => {
+    const gross = Decimal.from(100);
+    expect(getExitFeeAmount(gross, 50).toString()).toEqual('0.5'); // 0.5%
+    expect(getExitFeeNet(gross, 50).toString()).toEqual('99.5');
+    expect(getExitFeeAmount(gross, 0).isZero()).toBe(true);
+    expect(getExitFeeNet(gross, 0).toString()).toEqual('100');
+    expect(getExitFeeAmount(gross, EXIT_FEE_MAX_BPS).toString()).toEqual('100');
+  });
+
+  it('display gate: only active, sane-rate, non-zero fees are shown', () => {
+    const fee = Decimal.from('0.5');
+    expect(isExitFeeShown(true, 50, fee)).toBe(true);
+    expect(isExitFeeShown(false, 50, fee)).toBe(false);
+    expect(isExitFeeShown(true, 0, fee)).toBe(false);
+    expect(isExitFeeShown(true, 10001, fee)).toBe(false);
+    expect(isExitFeeShown(true, 50, Decimal.ZERO)).toBe(false);
+  });
+});

--- a/apps/frontend/src/utils/exitFee.test.ts
+++ b/apps/frontend/src/utils/exitFee.test.ts
@@ -68,12 +68,14 @@ describe('exitFee utils', () => {
     expect(getExitFeeDisplay(q(true, 0), fee)).toBe('none');
     expect(getExitFeeDisplay(q(true, 10001), fee)).toBe('none');
     expect(getExitFeeDisplay(q(true, 50), Decimal.ZERO)).toBe('none');
-    // The states the old predicate could not express at all.
+    // Fail-hidden: a quote not yet arrived, or not obtainable, shows nothing.
+    // The chain charges nothing in those cases and pays the gross, so the
+    // form rendering as it did before the perimeter is the truthful display.
     expect(getExitFeeDisplay({ ...q(true, 50), unknown: true }, fee)).toBe(
-      'unknown',
+      'none',
     );
     expect(getExitFeeDisplay({ ...q(true, 50), loading: true }, fee)).toBe(
-      'unknown',
+      'none',
     );
   });
 });

--- a/apps/frontend/src/utils/exitFee.test.ts
+++ b/apps/frontend/src/utils/exitFee.test.ts
@@ -10,7 +10,7 @@ import {
   SURFACE_ZERO_WITHDRAW_COLL,
   getExitFeeAmount,
   getExitFeeNet,
-  isExitFeeShown,
+  getExitFeeDisplay,
 } from './exitFee';
 
 describe('exitFee utils', () => {
@@ -55,10 +55,25 @@ describe('exitFee utils', () => {
 
   it('display gate: only active, sane-rate, non-zero fees are shown', () => {
     const fee = Decimal.from('0.5');
-    expect(isExitFeeShown(true, 50, fee)).toBe(true);
-    expect(isExitFeeShown(false, 50, fee)).toBe(false);
-    expect(isExitFeeShown(true, 0, fee)).toBe(false);
-    expect(isExitFeeShown(true, 10001, fee)).toBe(false);
-    expect(isExitFeeShown(true, 50, Decimal.ZERO)).toBe(false);
+    // Exercised through the exported decision, which is the only way a
+    // consumer can reach the charge test.
+    const q = (active: boolean, rateBps: number) => ({
+      active,
+      rateBps,
+      unknown: false,
+      loading: false,
+    });
+    expect(getExitFeeDisplay(q(true, 50), fee)).toBe('charged');
+    expect(getExitFeeDisplay(q(false, 50), fee)).toBe('none');
+    expect(getExitFeeDisplay(q(true, 0), fee)).toBe('none');
+    expect(getExitFeeDisplay(q(true, 10001), fee)).toBe('none');
+    expect(getExitFeeDisplay(q(true, 50), Decimal.ZERO)).toBe('none');
+    // The states the old predicate could not express at all.
+    expect(getExitFeeDisplay({ ...q(true, 50), unknown: true }, fee)).toBe(
+      'unknown',
+    );
+    expect(getExitFeeDisplay({ ...q(true, 50), loading: true }, fee)).toBe(
+      'unknown',
+    );
   });
 });

--- a/apps/frontend/src/utils/exitFee.test.ts
+++ b/apps/frontend/src/utils/exitFee.test.ts
@@ -7,6 +7,7 @@ import {
   SURFACE_LENDING_BORROWER_WITHDRAW,
   SURFACE_LENDING_LENDER_WITHDRAW,
   SURFACE_ZERO_CLAIM_SURPLUS,
+  SURFACE_ZERO_WITHDRAW_COLL,
   getExitFeeAmount,
   getExitFeeNet,
   isExitFeeShown,
@@ -15,23 +16,31 @@ import {
 describe('exitFee utils', () => {
   it('surface ids match keccak256 of the registry preimages', () => {
     expect(SURFACE_LENDING_LENDER_WITHDRAW).toEqual(
-      utils.id('COLFEE:SURFACE_LENDING_LENDER_WITHDRAW'),
+      utils.id('PERIMETER_SURFACE_LENDING_LENDER_WITHDRAW'),
     );
     expect(SURFACE_LENDING_BORROWER_WITHDRAW).toEqual(
-      utils.id('COLFEE:SURFACE_LENDING_BORROWER_WITHDRAW'),
+      utils.id('PERIMETER_SURFACE_LENDING_BORROWER_WITHDRAW'),
+    );
+    expect(SURFACE_ZERO_WITHDRAW_COLL).toEqual(
+      utils.id('PERIMETER_SURFACE_ZERO_WITHDRAW_COLL'),
     );
     expect(SURFACE_ZERO_CLAIM_SURPLUS).toEqual(
-      utils.id('COLFEE:SURFACE_ZERO_CLAIM_SURPLUS'),
+      utils.id('PERIMETER_SURFACE_ZERO_CLAIM_SURPLUS'),
     );
-    // pin the literals so a typo in the preimage string cannot pass silently
+    // Pin the literals too. The preimage assertions above cannot catch a
+    // rename that rewrites the constant and its own expectation together —
+    // which is exactly how a stale `COLFEE:` prefix survived once.
     expect(SURFACE_LENDING_LENDER_WITHDRAW).toEqual(
-      '0x3d0383a7986bf042db59f806aef31f95d28262f3280554c8541c299fa8e2ffb3',
+      '0xd4896528a9fba849e3d3db442dea05ef8f08c93e00cc760acac34c42a7dacffe',
     );
     expect(SURFACE_LENDING_BORROWER_WITHDRAW).toEqual(
-      '0x5c408ce1df6222b56e2084e292cdc734b880e9adbb4df2331d304431936967f7',
+      '0xfa502ea562018a194d7f66e337810fa8b882ec21f706f3b3c709a53fa126b018',
+    );
+    expect(SURFACE_ZERO_WITHDRAW_COLL).toEqual(
+      '0xfb3234ca0cf70fe9c90b73939f36a37fadcfdef4628afc42dd57d1f26dfd8fb5',
     );
     expect(SURFACE_ZERO_CLAIM_SURPLUS).toEqual(
-      '0xdd1d6592d9143b113f128998b830887d87bf784969f0bdeda154f2a49ca302e0',
+      '0x44224716871939619faf861b30e39bac8861d4f76b5dd0468d31bf4b7dc684be',
     );
   });
 

--- a/apps/frontend/src/utils/exitFee.ts
+++ b/apps/frontend/src/utils/exitFee.ts
@@ -61,21 +61,28 @@ export type ExitFeeQuote = {
   unknown: boolean;
 };
 
-/** What the UI should show. Three states, because there are three truths. */
-export type ExitFeeDisplay = 'charged' | 'none' | 'unknown';
-
 /**
- * The single display decision. Folds `loading` in deliberately: a quote that
- * has not arrived yet is not evidence of a zero fee, and every consumer that
- * destructured `{ active, rateBps }` and dropped `loading` rendered "no fee"
- * during the first fetch and for the whole cache TTL after any RPC blip.
+ * What the UI shows: the fee rows, or nothing at all.
+ *
+ * Fail-hidden. The rows appear only for a quote that has ARRIVED and says a
+ * fee is charged. Everything else — charging off, no policy, dust, a quote
+ * still loading, a quote we could not obtain — renders exactly as the form
+ * did before the perimeter existed. The chain fails open the same way: when it
+ * cannot quote, it charges nothing and pays the gross, so a form that says
+ * nothing in those cases is telling the truth.
+ *
+ * There is deliberately no third state. "A fee applies but we cannot say how
+ * much" is not a message this product sends: if no fee is taken, the user
+ * receives the whole amount and has nothing to be told.
  */
+export type ExitFeeDisplay = 'charged' | 'none';
+
 export const getExitFeeDisplay = (
   quote: ExitFeeQuote,
   fee: Decimal,
 ): ExitFeeDisplay => {
   if (quote.loading || quote.unknown) {
-    return 'unknown';
+    return 'none';
   }
   return isExitFeeShown(quote.active, quote.rateBps, fee) ? 'charged' : 'none';
 };

--- a/apps/frontend/src/utils/exitFee.ts
+++ b/apps/frontend/src/utils/exitFee.ts
@@ -29,9 +29,51 @@ export const getExitFeeAmount = (gross: Decimal, rateBps: number): Decimal =>
 export const getExitFeeNet = (gross: Decimal, rateBps: number): Decimal =>
   gross.sub(getExitFeeAmount(gross, rateBps));
 
-/** Mirror of the on-chain charge test (PERIMETER_FEE_CALL_GRAPH.md §"Quoting for UIs"). */
+/**
+ * Mirror of the on-chain charge test (PERIMETER_FEE_CALL_GRAPH.md §"Quoting for UIs").
+ *
+ * This answers "would a fee be charged", and ONLY that. It cannot tell you
+ * whether the quote behind `active`/`rateBps` was actually obtained — pass the
+ * whole quote to `getExitFeeDisplay` instead of calling this directly.
+ */
 export const isExitFeeShown = (
   active: boolean,
   rateBps: number,
   fee: Decimal,
 ): boolean => active && rateBps > 0 && rateBps <= EXIT_FEE_MAX_BPS && fee.gt(0);
+
+/**
+ * A quote, including whether we managed to get one.
+ *
+ * `unknown` exists because the perimeter fails open on chain: an unreachable
+ * controller, a reverting call or a surface with no policy all resolve to "no
+ * fee". Those are indistinguishable from a deliberate zero rate in the raw
+ * numbers, so the hooks report which of the two happened here rather than
+ * flattening both to `active: false`.
+ */
+export type ExitFeeQuote = {
+  active: boolean;
+  rateBps: number;
+  loading: boolean;
+  /** True when no quote was obtained. NOT the same as a rate of zero. */
+  unknown: boolean;
+};
+
+/** What the UI should show. Three states, because there are three truths. */
+export type ExitFeeDisplay = 'charged' | 'none' | 'unknown';
+
+/**
+ * The single display decision. Folds `loading` in deliberately: a quote that
+ * has not arrived yet is not evidence of a zero fee, and every consumer that
+ * destructured `{ active, rateBps }` and dropped `loading` rendered "no fee"
+ * during the first fetch and for the whole cache TTL after any RPC blip.
+ */
+export const getExitFeeDisplay = (
+  quote: ExitFeeQuote,
+  fee: Decimal,
+): ExitFeeDisplay => {
+  if (quote.loading || quote.unknown) {
+    return 'unknown';
+  }
+  return isExitFeeShown(quote.active, quote.rateBps, fee) ? 'charged' : 'none';
+};

--- a/apps/frontend/src/utils/exitFee.ts
+++ b/apps/frontend/src/utils/exitFee.ts
@@ -14,6 +14,10 @@ export const SURFACE_LENDING_LENDER_WITHDRAW =
   '0xd4896528a9fba849e3d3db442dea05ef8f08c93e00cc760acac34c42a7dacffe';
 export const SURFACE_LENDING_BORROWER_WITHDRAW =
   '0xfa502ea562018a194d7f66e337810fa8b882ec21f706f3b3c709a53fa126b018';
+// Not consumed by any component: the Zero collateral-withdrawal fee comes from
+// the contract's own previewZeroCollWithdrawExitFee, which resolves the surface
+// on chain. It is declared and pinned anyway, as a drift canary — the test below
+// fails if this id stops matching the contracts. Do not delete it as dead code.
 export const SURFACE_ZERO_WITHDRAW_COLL =
   '0xfb3234ca0cf70fe9c90b73939f36a37fadcfdef4628afc42dd57d1f26dfd8fb5';
 export const SURFACE_ZERO_CLAIM_SURPLUS =

--- a/apps/frontend/src/utils/exitFee.ts
+++ b/apps/frontend/src/utils/exitFee.ts
@@ -6,14 +6,18 @@ export const EXIT_FEE_MAX_BPS = 10_000;
 /** 1e18 reference gross used when only the resolved rate is needed. */
 export const EXIT_FEE_REFERENCE_GROSS = '1000000000000000000';
 
-// keccak256(utf8(preimage)) — the on-chain surface ids of the Sovryn Perimeter Fee;
-// verified against the deployed lending/Zero consumer constants
+// keccak256(utf8(preimage)) — the on-chain surface ids of the Sovryn Perimeter.
+// Each preimage is the literal name of the constant the consumer contracts
+// declare, so the id and the name cannot drift apart. Verified against the
+// deployed lending and Zero consumers; pinned in exitFee.test.ts.
 export const SURFACE_LENDING_LENDER_WITHDRAW =
-  '0x3d0383a7986bf042db59f806aef31f95d28262f3280554c8541c299fa8e2ffb3';
+  '0xd4896528a9fba849e3d3db442dea05ef8f08c93e00cc760acac34c42a7dacffe';
 export const SURFACE_LENDING_BORROWER_WITHDRAW =
-  '0x5c408ce1df6222b56e2084e292cdc734b880e9adbb4df2331d304431936967f7';
+  '0xfa502ea562018a194d7f66e337810fa8b882ec21f706f3b3c709a53fa126b018';
+export const SURFACE_ZERO_WITHDRAW_COLL =
+  '0xfb3234ca0cf70fe9c90b73939f36a37fadcfdef4628afc42dd57d1f26dfd8fb5';
 export const SURFACE_ZERO_CLAIM_SURPLUS =
-  '0xdd1d6592d9143b113f128998b830887d87bf784969f0bdeda154f2a49ca302e0';
+  '0x44224716871939619faf861b30e39bac8861d4f76b5dd0468d31bf4b7dc684be';
 
 export const getExitFeeAmount = (gross: Decimal, rateBps: number): Decimal =>
   gross.mul(rateBps).div(EXIT_FEE_MAX_BPS);

--- a/apps/frontend/src/utils/exitFee.ts
+++ b/apps/frontend/src/utils/exitFee.ts
@@ -32,11 +32,13 @@ export const getExitFeeNet = (gross: Decimal, rateBps: number): Decimal =>
 /**
  * Mirror of the on-chain charge test (PERIMETER_FEE_CALL_GRAPH.md §"Quoting for UIs").
  *
- * This answers "would a fee be charged", and ONLY that. It cannot tell you
- * whether the quote behind `active`/`rateBps` was actually obtained — pass the
- * whole quote to `getExitFeeDisplay` instead of calling this directly.
+ * Deliberately NOT exported. It answers "would a fee be charged" and only that,
+ * so on its own it cannot tell a rate of zero from a rate nobody could read —
+ * and four separate consumers reached that wrong conclusion by calling it
+ * directly. `getExitFeeDisplay` is the exported entry point; keeping this
+ * private makes the mistake a compile error rather than a review finding.
  */
-export const isExitFeeShown = (
+const isExitFeeShown = (
   active: boolean,
   rateBps: number,
   fee: Decimal,

--- a/apps/frontend/src/utils/exitFee.ts
+++ b/apps/frontend/src/utils/exitFee.ts
@@ -1,0 +1,29 @@
+import { Decimal } from '@sovryn/utils';
+
+/** 30 s — the perimeter's operational admin can change policy instantly (no timelock), so cache briefly. */
+export const EXIT_FEE_TTL = 30_000;
+export const EXIT_FEE_MAX_BPS = 10_000;
+/** 1e18 reference gross used when only the resolved rate is needed. */
+export const EXIT_FEE_REFERENCE_GROSS = '1000000000000000000';
+
+// keccak256(utf8(preimage)) — the on-chain surface ids of the Sovryn Perimeter Fee;
+// verified against the deployed lending/Zero consumer constants
+export const SURFACE_LENDING_LENDER_WITHDRAW =
+  '0x3d0383a7986bf042db59f806aef31f95d28262f3280554c8541c299fa8e2ffb3';
+export const SURFACE_LENDING_BORROWER_WITHDRAW =
+  '0x5c408ce1df6222b56e2084e292cdc734b880e9adbb4df2331d304431936967f7';
+export const SURFACE_ZERO_CLAIM_SURPLUS =
+  '0xdd1d6592d9143b113f128998b830887d87bf784969f0bdeda154f2a49ca302e0';
+
+export const getExitFeeAmount = (gross: Decimal, rateBps: number): Decimal =>
+  gross.mul(rateBps).div(EXIT_FEE_MAX_BPS);
+
+export const getExitFeeNet = (gross: Decimal, rateBps: number): Decimal =>
+  gross.sub(getExitFeeAmount(gross, rateBps));
+
+/** Mirror of the on-chain charge test (PERIMETER_FEE_CALL_GRAPH.md §"Quoting for UIs"). */
+export const isExitFeeShown = (
+  active: boolean,
+  rateBps: number,
+  fee: Decimal,
+): boolean => active && rateBps > 0 && rateBps <= EXIT_FEE_MAX_BPS && fee.gt(0);


### PR DESCRIPTION
## Sovryn Perimeter Fee — fee display on withdraw and close flows

Shows the perimeter fee (rate, amount, and net "You will receive") on lending
withdrawals, borrower exits, Zero collateral withdrawal/close, and the surplus-claim
view. Part of the Security Perimeter phase 1 release ([SIP-0094 @ `340148c`](https://github.com/DistributedCollective/SIPS/blob/340148c88b827cd61c2f99cd825e7ce71bf94539/SIP-0094.md), sha256 `496b69a6761f4e41d5e551f9c9f3962570beaba9e4aeb66613265c97fe09c756` — the shipping pin the three on-chain proposals carry in their descriptions).

### Dormant until governance acts

Display is gated **purely on on-chain state** and fails hidden: a fee row renders only
when the deployed ExitFeeController quotes an *active* policy with a non-zero rate and
fee for that surface. Until SIP-0094 executes and charging is enabled, every form
renders exactly as it does on `develop` today — no feature flag, no env var, nothing to
configure. Once charging is enabled on-chain, the display lights up on its own (quotes
are cached for 30 seconds).

### Merge timing — opposite of the contract PRs, deliberately

The contract PRs (Sovryn-smart-contracts#580, zero-contracts#10) merge only **after**
the SIP executes. This PR should merge and deploy **before** charging is enabled: the
UI is provably inert until then, and having it live first guarantees users see the fee
the moment it exists. The one ordering that must not happen is enabling charging while
the dapp still lacks this UI — fees would apply without being displayed.

### Notes for reviewers

- All user-facing copy says **"Perimeter fee"** (renamed from the internal working title
  during this port; tests pin the new copy). Internal identifiers and the on-chain
  surface-id constants are unchanged — the ids are keccak hashes verified against the
  deployed consumer contracts.
- Rebased onto current `develop`. 
- Affected tests: 11 suites / 38 tests green locally via the pre-commit hook.
- The Spanish locale remains the app-wide English-fallback stub; no fee-specific
  regression there.

